### PR TITLE
Error creating secret

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,13 +19,13 @@ install:
 	cd frontend && npm install
 	@make hooks
 
-backend:
+backend: migrate
 	cd backend && poetry run uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
 
 frontend:
 	cd frontend && npm run dev
 
-dev:
+dev: migrate
 	@echo "Starting backend and frontend..."
 	@echo "Backend: http://localhost:8000"
 	@echo "Frontend: http://localhost:5173"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,8 +4,10 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
+from sqlalchemy import inspect
 
 from app.config import settings
+from app.database import engine
 from app.middleware.rate_limit import limiter
 from app.routers import challenges, secrets
 from app.scheduler import shutdown_scheduler, start_scheduler
@@ -14,9 +16,30 @@ from app.scheduler import shutdown_scheduler, start_scheduler
 # Run: poetry run alembic upgrade head
 
 
+def check_database_tables():
+    """
+    Check that required database tables exist.
+
+    Raises RuntimeError with helpful message if tables are missing.
+    This helps catch the case where migrations haven't been run.
+    """
+    required_tables = {"secrets", "pow_challenges"}
+    inspector = inspect(engine)
+    existing_tables = set(inspector.get_table_names())
+
+    missing_tables = required_tables - existing_tables
+    if missing_tables:
+        raise RuntimeError(
+            f"Database tables missing: {missing_tables}. "
+            "Please run database migrations first: make migrate "
+            "(or: cd backend && poetry run alembic upgrade head)"
+        )
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Manage application lifecycle - start/stop scheduler."""
+    check_database_tables()
     start_scheduler()
     yield
     shutdown_scheduler()

--- a/backend/tests/test_database_startup.py
+++ b/backend/tests/test_database_startup.py
@@ -1,0 +1,88 @@
+"""Tests for database initialization and startup behavior.
+
+These tests verify that the application handles database state correctly,
+particularly when migrations haven't been run.
+"""
+
+import os
+import tempfile
+
+import pytest
+from sqlalchemy import create_engine, inspect
+
+
+class TestDatabaseStartup:
+    """Tests for database initialization at startup."""
+
+    def test_check_database_tables_raises_on_missing_tables(self):
+        """
+        Test that check_database_tables() raises RuntimeError when tables are missing.
+
+        This verifies the fix for Issue #31 where running `make dev` without
+        `make migrate` causes: sqlite3.OperationalError: no such table: pow_challenges
+        """
+        from app.main import check_database_tables
+
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as tmp:
+            empty_db_path = tmp.name
+
+        try:
+            # Create an empty database (no tables)
+            empty_engine = create_engine(
+                f"sqlite:///{empty_db_path}",
+                connect_args={"check_same_thread": False},
+            )
+
+            # Verify it's empty
+            inspector = inspect(empty_engine)
+            assert len(inspector.get_table_names()) == 0
+
+            # Temporarily patch the engine used by check_database_tables
+            import app.main as main_module
+
+            original_engine = main_module.engine
+            main_module.engine = empty_engine
+
+            try:
+                with pytest.raises(RuntimeError) as exc_info:
+                    check_database_tables()
+
+                error_message = str(exc_info.value)
+                assert "Database tables missing" in error_message
+                assert "make migrate" in error_message
+            finally:
+                main_module.engine = original_engine
+
+        finally:
+            if os.path.exists(empty_db_path):
+                os.unlink(empty_db_path)
+
+    def test_check_database_tables_passes_with_all_tables(self, db_session):
+        """
+        Test that check_database_tables() passes when all tables exist.
+        """
+        import app.main as main_module
+        from app.main import check_database_tables
+
+        # Use the test session's engine which has all tables created
+        original_engine = main_module.engine
+        main_module.engine = db_session.get_bind()
+
+        try:
+            # Should not raise any exception
+            check_database_tables()
+        finally:
+            main_module.engine = original_engine
+
+    def test_required_tables_exist_after_setup(self, db_session):
+        """
+        Test that the required tables exist after proper setup.
+        """
+        engine = db_session.get_bind()
+        inspector = inspect(engine)
+        tables = set(inspector.get_table_names())
+
+        required_tables = {"secrets", "pow_challenges"}
+        assert required_tables.issubset(
+            tables
+        ), f"Missing required tables. Expected: {required_tables}, Found: {tables}"


### PR DESCRIPTION
## Summary
- Auto-run database migrations when starting the dev server with `make dev` or `make backend`
- Add startup check that provides a helpful error message if database tables are missing
- Update test fixtures to properly handle the database table check

## Root Cause
When running `make dev` without first running `make migrate`, the application crashed with:
```
sqlite3.OperationalError: no such table: pow_challenges
```

The database tables are created by Alembic migrations, but the `dev` target didn't automatically run migrations first.

## Test plan
- [x] Delete `backend/secrets.db` and run `make dev` - should auto-run migrations and start successfully
- [x] All 28 backend tests pass
- [x] All 58 frontend tests pass
- [x] `make check` passes (lint, format, typecheck, test)

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)