### PR TITLE
fix: harden deployment workflows and scripts

### DIFF
--- a/.github/workflows/build-and-deploy-staging.yml
+++ b/.github/workflows/build-and-deploy-staging.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
           cache: "npm"
           cache-dependency-path: frontend/package-lock.json
       - name: Install frontend deps
@@ -92,19 +92,20 @@ jobs:
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
           echo "${{ secrets.STAGING_SSH_KNOWN_HOSTS }}" >> ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
 
       - name: Deploy (remote)
         run: |
           short_sha="${GITHUB_SHA::7}"
           backend="ghcr.io/${GITHUB_REPOSITORY_OWNER}/in-the-event-of-my-death-backend:sha-${short_sha}"
           web="ghcr.io/${GITHUB_REPOSITORY_OWNER}/in-the-event-of-my-death-web:sha-${short_sha}"
-          ssh "${{ secrets.STAGING_SSH_USER }}@${{ secrets.STAGING_SSH_HOST }}" \
+          ssh -o BatchMode=yes -o ConnectTimeout=10 "${{ secrets.STAGING_SSH_USER }}@${{ secrets.STAGING_SSH_HOST }}" \
             "sudo /usr/local/bin/ieomd-deploy deploy --dir /opt/ieomd --backend-image ${backend} --web-image ${web}"
 
       - name: Smoke test
         run: |
           for i in $(seq 1 30); do
-            if curl -fsS "https://${{ secrets.STAGING_SITE_HOST }}/health" | jq -e '.status == "healthy"' > /dev/null; then
+            if curl -fsS "https://${{ secrets.STAGING_SITE_HOST }}/health" | python3 -c 'import json,sys; sys.exit(0 if json.load(sys.stdin).get("status") == "healthy" else 1)'; then
               exit 0
             fi
             sleep 2

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -25,18 +25,19 @@ jobs:
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
           echo "${{ secrets.PROD_SSH_KNOWN_HOSTS }}" >> ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
 
       - name: Deploy (remote)
         run: |
           backend="ghcr.io/${GITHUB_REPOSITORY_OWNER}/in-the-event-of-my-death-backend:${{ inputs.tag }}"
           web="ghcr.io/${GITHUB_REPOSITORY_OWNER}/in-the-event-of-my-death-web:${{ inputs.tag }}"
-          ssh "${{ secrets.PROD_SSH_USER }}@${{ secrets.PROD_SSH_HOST }}" \
+          ssh -o BatchMode=yes -o ConnectTimeout=10 "${{ secrets.PROD_SSH_USER }}@${{ secrets.PROD_SSH_HOST }}" \
             "sudo /usr/local/bin/ieomd-deploy deploy --dir /opt/ieomd --backend-image ${backend} --web-image ${web}"
 
       - name: Smoke test
         run: |
           for i in $(seq 1 30); do
-            if curl -fsS "https://${{ secrets.PROD_SITE_HOST }}/health" | jq -e '.status == "healthy"' > /dev/null; then
+            if curl -fsS "https://${{ secrets.PROD_SITE_HOST }}/health" | python3 -c 'import json,sys; sys.exit(0 if json.load(sys.stdin).get("status") == "healthy" else 1)'; then
               exit 0
             fi
             sleep 2

--- a/deploy/remote/ieomd-deploy
+++ b/deploy/remote/ieomd-deploy
@@ -61,6 +61,13 @@ if [[ -f "$state_file" ]]; then
   previous_web_image="${WEB_IMAGE:-}"
 fi
 
+if [[ -f "$deploy_dir/.env" ]]; then
+  set -a
+  # shellcheck source=/dev/null
+  source "$deploy_dir/.env"
+  set +a
+fi
+
 rollback() {
   trap - ERR
   set +e
@@ -69,6 +76,7 @@ rollback() {
 
   if [[ -n "$backup_path" && -f "$backup_path" ]]; then
     echo "[ieomd] restoring DB from backup $backup_path" >&2
+    mkdir -p "$(dirname "$db_path")"
     cp -a "$backup_path" "$db_path"
   fi
 
@@ -92,13 +100,22 @@ cd "$deploy_dir"
 echo "[ieomd] pulling images..."
 BACKEND_IMAGE="$backend_image" WEB_IMAGE="$web_image" docker compose pull
 
-db_path="${DB_PATH:-/var/lib/ieomd/secrets.db}"
+data_dir="${DATA_DIR:-/var/lib/ieomd}"
+
+if [[ -n "${DB_PATH:-}" ]]; then
+  db_path="$DB_PATH"
+elif [[ "${DATABASE_URL:-}" =~ ^sqlite:////data/(.+)$ ]]; then
+  db_path="$data_dir/${BASH_REMATCH[1]}"
+else
+  db_path="$data_dir/secrets.db"
+fi
 
 echo "[ieomd] stopping backend (maintenance window)..."
 docker compose stop backend || true
 
 if [[ -f "$db_path" ]]; then
-  backup_path="$backup_dir/secrets.db.$timestamp"
+  db_name="$(basename "$db_path")"
+  backup_path="$backup_dir/$db_name.$timestamp"
   echo "[ieomd] backing up DB to $backup_path"
   cp -a "$db_path" "$backup_path"
 else


### PR DESCRIPTION
## Summary

Hardens the deployment infrastructure with several improvements:

- Upgrade Node.js from 18 to 20 in CI
- Add `chmod 600` on known_hosts files for stricter permissions
- Add `BatchMode=yes` and `ConnectTimeout=10` to SSH commands for better failure handling
- Replace `jq` with `python3` for JSON parsing (more portable across runners)
- Source `.env` in deploy script for environment variables
- Improve DB path detection from `DATABASE_URL`
- Fix backup filename to use actual DB name (supports staging vs prod DBs)

## Test plan

- [ ] CI checks pass
- [ ] Merge and verify staging auto-deploy succeeds
- [ ] Verify health endpoint responds at staging.ieomd.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)