### PR TITLE
fix: update frontend Dockerfile to Node 20

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine AS build
+FROM node:20-alpine AS build
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

Updates the frontend Dockerfile from Node 18 to Node 20 to fix build failures.

## Problem

The Vite build was failing with worker bundling errors:
```
file: /app/src/services/pow.ts
ERROR: process "/bin/sh -c npm run build" did not complete successfully: exit code: 1
```

## Solution

Update `node:18-alpine` → `node:20-alpine` to match the CI workflow (updated in PR #41).

Closes #42

## Test plan

- [ ] CI passes
- [ ] Docker build succeeds
- [ ] Staging deploy completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)