### PR TITLE
fix: use explicit handle blocks for Caddyfile routing

### DIFF
--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -6,13 +6,18 @@
 {$SITE_ADDRESS} {
 	encode gzip
 
-	@api path /api/* /health
-	handle @api {
+	handle /api/* {
 		reverse_proxy backend:8000
 	}
 
-	root * /srv
-	try_files {path} /index.html
-	file_server
+	handle /health {
+		reverse_proxy backend:8000
+	}
+
+	handle {
+		root * /srv
+		try_files {path} /index.html
+		file_server
+	}
 }
 


### PR DESCRIPTION
## Summary
- Fix Caddy routing to properly proxy `/api/*` and `/health` to backend
- Use explicit `handle` blocks instead of named matchers to ensure correct directive ordering

## Problem
Caddy's directive ordering was causing `file_server` and `try_files` to match before the API routes, resulting in all requests returning the frontend HTML instead of being proxied to the backend.

## Solution
Wrap all route handling in explicit `handle` blocks:
1. `handle /api/*` - proxy to backend
2. `handle /health` - proxy to backend  
3. `handle` (catch-all) - serve static files with SPA fallback

## Test plan
- [ ] Verify `curl https://staging.ieomd.com/health` returns `{"status":"healthy"}`
- [ ] Verify `curl https://staging.ieomd.com/api/challenge` returns challenge JSON
- [ ] Verify `curl https://staging.ieomd.com/` returns frontend HTML

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)