### PR TITLE
fix: staging uses same-origin API base

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Frontend (starts on http://localhost:5173):
 make frontend
 ```
 
-The frontend will proxy API requests to the backend automatically.
+The frontend calls the backend API at `${VITE_API_URL}/api/v1` (in production it defaults to same-origin `/api/v1`).
 
 ### Development Commands
 
@@ -140,7 +140,7 @@ VITE_BASE_URL=http://localhost:5173
 ```
 
 **Variables:**
-- `VITE_API_URL`: URL of the backend API server
+- `VITE_API_URL`: Optional backend server URL (origin). The frontend calls `${VITE_API_URL}/api/v1/...`. If unset in production, it defaults to same-origin `/api/v1`.
 - `VITE_BASE_URL`: Base URL used for generating shareable links. In production, this should be set to your production domain
 
 ### Backend Configuration

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,5 +1,6 @@
 # API Configuration
-# URL of the backend API server
+# Optional: URL of the backend server (origin). The app will call `${VITE_API_URL}/api/v1/...`.
+# In production, you can usually omit this and the app will use same-origin `/api/v1`.
 VITE_API_URL=http://localhost:8000
 
 # Base URL for shareable links

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -10,7 +10,13 @@ import type {
   SecretRetrieveResponse,
 } from '../types'
 
-const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8000/api/v1'
+import { resolveApiBaseUrl } from './apiBase'
+
+const API_BASE = resolveApiBaseUrl({
+  apiUrl: import.meta.env.VITE_API_URL,
+  isDev: import.meta.env.DEV,
+  origin: window.location.origin,
+})
 
 class ApiError extends Error {
   status: number

--- a/frontend/src/services/apiBase.test.ts
+++ b/frontend/src/services/apiBase.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { resolveApiBaseUrl } from './apiBase'
+
+describe('resolveApiBaseUrl', () => {
+  it('defaults to local backend in dev', () => {
+    expect(resolveApiBaseUrl({ isDev: true, origin: 'http://localhost:5173' })).toBe(
+      'http://localhost:8000/api/v1',
+    )
+  })
+
+  it('defaults to same-origin in prod', () => {
+    expect(resolveApiBaseUrl({ isDev: false, origin: 'https://staging.ieomd.com' })).toBe(
+      'https://staging.ieomd.com/api/v1',
+    )
+  })
+
+  it('accepts configured backend origin and appends /api/v1', () => {
+    expect(
+      resolveApiBaseUrl({
+        apiUrl: 'https://api-staging.ieomd.com',
+        isDev: false,
+        origin: 'https://staging.ieomd.com',
+      }),
+    ).toBe('https://api-staging.ieomd.com/api/v1')
+  })
+
+  it('accepts configured /api/v1 base directly', () => {
+    expect(
+      resolveApiBaseUrl({
+        apiUrl: 'https://staging.ieomd.com/api/v1',
+        isDev: false,
+        origin: 'https://staging.ieomd.com',
+      }),
+    ).toBe('https://staging.ieomd.com/api/v1')
+  })
+
+  it('accepts relative /api/v1', () => {
+    expect(
+      resolveApiBaseUrl({
+        apiUrl: '/api/v1',
+        isDev: false,
+        origin: 'https://staging.ieomd.com',
+      }),
+    ).toBe('https://staging.ieomd.com/api/v1')
+  })
+})

--- a/frontend/src/services/apiBase.ts
+++ b/frontend/src/services/apiBase.ts
@@ -1,0 +1,48 @@
+type ResolveApiBaseUrlOptions = {
+  /**
+   * Optional override for the backend server URL.
+   * Accepts either an absolute URL (e.g. https://api.example.com)
+   * or a relative path (e.g. /api/v1).
+   */
+  apiUrl?: string
+  /**
+   * Whether we're running in dev mode (Vite).
+   * In dev, default to a local backend for convenience.
+   */
+  isDev: boolean
+  /**
+   * The current page origin, used to resolve relative URLs.
+   */
+  origin: string
+}
+
+const DEFAULT_DEV_API_ORIGIN = 'http://localhost:8000'
+const API_PREFIX = '/api/v1'
+
+function toUrl(input: string, origin: string): URL {
+  const trimmed = input.trim()
+  if (trimmed.startsWith('/')) return new URL(trimmed, origin)
+  return new URL(trimmed)
+}
+
+function ensureApiPrefix(url: URL): URL {
+  const next = new URL(url.toString())
+  const normalizedPath = next.pathname.replace(/\/+$/, '')
+  if (normalizedPath === API_PREFIX) return next
+  next.pathname = API_PREFIX
+  return next
+}
+
+export function resolveApiBaseUrl(options: ResolveApiBaseUrlOptions): string {
+  const configured = options.apiUrl?.trim()
+  const base =
+    configured && configured.length > 0
+      ? configured
+      : options.isDev
+        ? DEFAULT_DEV_API_ORIGIN
+        : options.origin
+
+  const parsed = toUrl(base, options.origin)
+  const api = ensureApiPrefix(parsed)
+  return api.toString().replace(/\/+$/, '')
+}


### PR DESCRIPTION
Closes #51

## What
Staging frontend was defaulting API calls to `http://localhost:8000/api/v1` when `VITE_API_URL` wasn’t set, causing `Failed to fetch` for users.

## Fix
Default API base to same-origin `/api/v1` in production (matches Caddy reverse proxy), while keeping localhost as the dev default.

## Test
- `make check`
