### PR TITLE
Docs: update canonical domain to ieomd.com

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -2,7 +2,7 @@
 name = "in-the-event-of-my-death"
 version = "0.1.0-beta"
 description = "Zero-knowledge time-locked secret delivery service"
-authors = ["Your Name <you@example.com>"]
+authors = ["Rich Miles <rich@ieomd.com>"]
 package-mode = false
 
 [tool.poetry.dependencies]

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -32,8 +32,8 @@ Compose files live in `deploy/`.
    - `deploy/docker-compose.staging.yml` (staging only)
    - `deploy/Caddyfile` (if you want to override baked-in config)
 5. Create `/opt/ieomd/.env` with at least:
-   - `SITE_HOST=example.com`
-   - `SITE_ADDRESS=example.com, www.example.com` (Caddy site label(s))
+   - `SITE_HOST=ieomd.com`
+   - `SITE_ADDRESS=ieomd.com, www.ieomd.com` (Caddy site label(s))
    - `DATA_DIR=/var/lib/ieomd`
    - `DATABASE_URL=sqlite:////data/secrets.db`
 6. Ensure `/opt/ieomd` contains a compose override if needed.
@@ -51,9 +51,9 @@ Recommended approach:
 You’ll need repository secrets for staging and production:
 
 - `STAGING_SSH_HOST`, `STAGING_SSH_USER`, `STAGING_SSH_KEY`, `STAGING_SSH_KNOWN_HOSTS`
-- `STAGING_SITE_HOST` (e.g. `staging.example.com`)
+- `STAGING_SITE_HOST` (e.g. `staging.ieomd.com`)
 - `PROD_SSH_HOST`, `PROD_SSH_USER`, `PROD_SSH_KEY`, `PROD_SSH_KNOWN_HOSTS`
-- `PROD_SITE_HOST` (e.g. `example.com`)
+- `PROD_SITE_HOST` (e.g. `ieomd.com`)
 
 ## GHCR image pulls
 


### PR DESCRIPTION
## Summary
- Update deploy.md examples to use `ieomd.com` and `staging.ieomd.com` instead of `example.com`
- Update pyproject.toml author email to use ieomd.com domain

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)