### PR TITLE
fix: Handle curl connection failures in smoke tests

### DIFF
--- a/.github/workflows/build-and-deploy-staging.yml
+++ b/.github/workflows/build-and-deploy-staging.yml
@@ -105,7 +105,8 @@ jobs:
       - name: Smoke test
         run: |
           for i in $(seq 1 30); do
-            if curl -fsS "https://${{ secrets.STAGING_SITE_HOST }}/health" | python3 -c 'import json,sys; sys.exit(0 if json.load(sys.stdin).get("status") == "healthy" else 1)'; then
+            response=$(curl -sS --fail-with-body "https://${{ secrets.STAGING_SITE_HOST }}/health" 2>/dev/null) || { sleep 2; continue; }
+            if echo "$response" | python3 -c 'import json,sys; sys.exit(0 if json.load(sys.stdin).get("status") == "healthy" else 1)'; then
               exit 0
             fi
             sleep 2

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -37,7 +37,8 @@ jobs:
       - name: Smoke test
         run: |
           for i in $(seq 1 30); do
-            if curl -fsS "https://${{ secrets.PROD_SITE_HOST }}/health" | python3 -c 'import json,sys; sys.exit(0 if json.load(sys.stdin).get("status") == "healthy" else 1)'; then
+            response=$(curl -sS --fail-with-body "https://${{ secrets.PROD_SITE_HOST }}/health" 2>/dev/null) || { sleep 2; continue; }
+            if echo "$response" | python3 -c 'import json,sys; sys.exit(0 if json.load(sys.stdin).get("status") == "healthy" else 1)'; then
               exit 0
             fi
             sleep 2

--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -80,7 +80,8 @@ jobs:
       - name: Smoke test
         run: |
           for i in $(seq 1 30); do
-            if curl -fsS "https://${{ secrets.PROD_SITE_HOST }}/health" | python3 -c 'import json,sys; sys.exit(0 if json.load(sys.stdin).get("status") == "healthy" else 1)'; then
+            response=$(curl -sS --fail-with-body "https://${{ secrets.PROD_SITE_HOST }}/health" 2>/dev/null) || { sleep 2; continue; }
+            if echo "$response" | python3 -c 'import json,sys; sys.exit(0 if json.load(sys.stdin).get("status") == "healthy" else 1)'; then
               echo "✅ Production is healthy" >> "$GITHUB_STEP_SUMMARY"
               exit 0
             fi


### PR DESCRIPTION
## Summary

- Captures curl response before piping to Python
- If curl fails (connection refused, timeout, etc.), continues the retry loop
- Prevents JSON decode errors from empty input

## Problem

When curl can't connect (e.g., server still starting), it fails silently with `-f` flag but the script still pipes empty output to Python, causing:

```
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

## Solution

```bash
# Before (broken)
if curl -fsS "https://..." | python3 -c '...'; then

# After (fixed)
response=$(curl -sS --fail-with-body "https://..." 2>/dev/null) || { sleep 2; continue; }
if echo "$response" | python3 -c '...'; then
```

## Files changed
- `.github/workflows/promote-to-production.yml`
- `.github/workflows/deploy-production.yml`
- `.github/workflows/build-and-deploy-staging.yml`

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)