### PR TITLE
refactor: Add indexed token prefix to avoid O(N) Argon2 scans

### DIFF
--- a/backend/alembic/versions/0002_add_token_prefix_columns.py
+++ b/backend/alembic/versions/0002_add_token_prefix_columns.py
@@ -1,0 +1,77 @@
+"""Add token prefix columns for O(1) lookup
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2025-12-31
+
+Adds edit_token_prefix and decrypt_token_prefix columns to secrets table.
+These indexed columns store the first 16 hex chars of each token, enabling
+O(1) database lookup before Argon2 verification (instead of O(N) scans).
+
+For existing secrets (if any), we generate random prefixes since we can't
+recover the original tokens. These secrets will be orphaned but will
+expire naturally. This is acceptable for a new service with minimal data.
+"""
+
+import secrets
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0002"
+down_revision: str | None = "0001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Add columns as nullable first
+    op.add_column(
+        "secrets",
+        sa.Column("edit_token_prefix", sa.String(16), nullable=True),
+    )
+    op.add_column(
+        "secrets",
+        sa.Column("decrypt_token_prefix", sa.String(16), nullable=True),
+    )
+
+    # Backfill existing rows with random prefixes
+    # These secrets become orphaned but will expire naturally
+    connection = op.get_bind()
+    secrets_table = sa.table(
+        "secrets",
+        sa.column("id", sa.String),
+        sa.column("edit_token_prefix", sa.String),
+        sa.column("decrypt_token_prefix", sa.String),
+    )
+
+    # Get all existing secrets
+    result = connection.execute(sa.select(secrets_table.c.id))
+    for row in result:
+        connection.execute(
+            secrets_table.update()
+            .where(secrets_table.c.id == row.id)
+            .values(
+                edit_token_prefix=secrets.token_hex(8),  # 16 hex chars
+                decrypt_token_prefix=secrets.token_hex(8),
+            )
+        )
+
+    # Now make columns non-nullable
+    with op.batch_alter_table("secrets") as batch_op:
+        batch_op.alter_column("edit_token_prefix", nullable=False)
+        batch_op.alter_column("decrypt_token_prefix", nullable=False)
+
+    # Create indexes for fast prefix lookup
+    op.create_index("ix_secrets_edit_token_prefix", "secrets", ["edit_token_prefix"])
+    op.create_index("ix_secrets_decrypt_token_prefix", "secrets", ["decrypt_token_prefix"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_secrets_decrypt_token_prefix", table_name="secrets")
+    op.drop_index("ix_secrets_edit_token_prefix", table_name="secrets")
+    op.drop_column("secrets", "decrypt_token_prefix")
+    op.drop_column("secrets", "edit_token_prefix")

--- a/backend/app/models/secret.py
+++ b/backend/app/models/secret.py
@@ -11,6 +11,13 @@ class Secret(Base):
     __tablename__ = "secrets"
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+
+    # Token prefixes for O(1) lookup (first 16 hex chars of token)
+    # These are indexed and used to narrow down candidates before Argon2 verification
+    edit_token_prefix: Mapped[str] = mapped_column(String(16), index=True, nullable=False)
+    decrypt_token_prefix: Mapped[str] = mapped_column(String(16), index=True, nullable=False)
+
+    # Full Argon2 hashes for secure verification after prefix lookup
     edit_token_hash: Mapped[str] = mapped_column(String(128), unique=True, nullable=False)
     decrypt_token_hash: Mapped[str] = mapped_column(String(128), unique=True, nullable=False)
 

--- a/backend/tests/test_service.py
+++ b/backend/tests/test_service.py
@@ -6,7 +6,14 @@ from datetime import timedelta
 
 import pytest
 
-from app.services.secret_service import clear_expired_secrets, create_secret
+from app.services.secret_service import (
+    TOKEN_PREFIX_LENGTH,
+    clear_expired_secrets,
+    create_secret,
+    find_secret_by_decrypt_token,
+    find_secret_by_edit_token,
+    get_token_prefix,
+)
 from tests.test_utils import utcnow
 
 
@@ -171,3 +178,116 @@ class TestClearExpiredSecrets:
         assert cleared_count == 0
         db_session.refresh(expired_secret)
         assert expired_secret.cleared_at == first_cleared_at
+
+
+class TestTokenPrefixLookup:
+    """Tests for token prefix-based O(1) lookup."""
+
+    def test_get_token_prefix(self):
+        """Test that get_token_prefix extracts first 16 chars."""
+        token = "abcdef1234567890xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        prefix = get_token_prefix(token)
+        assert prefix == "abcdef1234567890"
+        assert len(prefix) == TOKEN_PREFIX_LENGTH
+
+    def test_create_secret_stores_prefixes(self, db_session, sample_tokens):
+        """Test that create_secret stores token prefixes."""
+        iv = base64.b64encode(secrets.token_bytes(12)).decode()
+        auth_tag = base64.b64encode(secrets.token_bytes(16)).decode()
+        ciphertext = base64.b64encode(secrets.token_bytes(100)).decode()
+
+        secret = create_secret(
+            db=db_session,
+            ciphertext_b64=ciphertext,
+            iv_b64=iv,
+            auth_tag_b64=auth_tag,
+            unlock_at=utcnow() + timedelta(hours=1),
+            edit_token=sample_tokens["edit_token"],
+            decrypt_token=sample_tokens["decrypt_token"],
+            expires_at=utcnow() + timedelta(days=7),
+        )
+
+        # Verify prefixes are stored correctly
+        assert secret.edit_token_prefix == sample_tokens["edit_token"][:TOKEN_PREFIX_LENGTH]
+        assert secret.decrypt_token_prefix == sample_tokens["decrypt_token"][:TOKEN_PREFIX_LENGTH]
+
+    def test_find_secret_by_edit_token_uses_prefix(self, db_session, sample_tokens):
+        """Test that find_secret_by_edit_token uses prefix for lookup."""
+        iv = base64.b64encode(secrets.token_bytes(12)).decode()
+        auth_tag = base64.b64encode(secrets.token_bytes(16)).decode()
+        ciphertext = base64.b64encode(secrets.token_bytes(100)).decode()
+
+        created = create_secret(
+            db=db_session,
+            ciphertext_b64=ciphertext,
+            iv_b64=iv,
+            auth_tag_b64=auth_tag,
+            unlock_at=utcnow() + timedelta(hours=1),
+            edit_token=sample_tokens["edit_token"],
+            decrypt_token=sample_tokens["decrypt_token"],
+            expires_at=utcnow() + timedelta(days=7),
+        )
+
+        # Find by edit token
+        found = find_secret_by_edit_token(db_session, sample_tokens["edit_token"])
+        assert found is not None
+        assert found.id == created.id
+
+        # Wrong token should not find it
+        wrong_token = secrets.token_hex(32)
+        not_found = find_secret_by_edit_token(db_session, wrong_token)
+        assert not_found is None
+
+    def test_find_secret_by_decrypt_token_uses_prefix(self, db_session, sample_tokens):
+        """Test that find_secret_by_decrypt_token uses prefix for lookup."""
+        iv = base64.b64encode(secrets.token_bytes(12)).decode()
+        auth_tag = base64.b64encode(secrets.token_bytes(16)).decode()
+        ciphertext = base64.b64encode(secrets.token_bytes(100)).decode()
+
+        created = create_secret(
+            db=db_session,
+            ciphertext_b64=ciphertext,
+            iv_b64=iv,
+            auth_tag_b64=auth_tag,
+            unlock_at=utcnow() + timedelta(hours=1),
+            edit_token=sample_tokens["edit_token"],
+            decrypt_token=sample_tokens["decrypt_token"],
+            expires_at=utcnow() + timedelta(days=7),
+        )
+
+        # Find by decrypt token
+        found = find_secret_by_decrypt_token(db_session, sample_tokens["decrypt_token"])
+        assert found is not None
+        assert found.id == created.id
+
+        # Wrong token should not find it
+        wrong_token = secrets.token_hex(32)
+        not_found = find_secret_by_decrypt_token(db_session, wrong_token)
+        assert not_found is None
+
+    def test_deleted_secrets_not_found_by_token(self, db_session, sample_tokens):
+        """Test that deleted secrets are not returned by token lookup."""
+        iv = base64.b64encode(secrets.token_bytes(12)).decode()
+        auth_tag = base64.b64encode(secrets.token_bytes(16)).decode()
+        ciphertext = base64.b64encode(secrets.token_bytes(100)).decode()
+
+        secret = create_secret(
+            db=db_session,
+            ciphertext_b64=ciphertext,
+            iv_b64=iv,
+            auth_tag_b64=auth_tag,
+            unlock_at=utcnow() + timedelta(hours=1),
+            edit_token=sample_tokens["edit_token"],
+            decrypt_token=sample_tokens["decrypt_token"],
+            expires_at=utcnow() + timedelta(days=7),
+        )
+
+        # Mark as deleted
+        secret.is_deleted = True
+        db_session.commit()
+
+        # Should not be found
+        found_by_edit = find_secret_by_edit_token(db_session, sample_tokens["edit_token"])
+        found_by_decrypt = find_secret_by_decrypt_token(db_session, sample_tokens["decrypt_token"])
+        assert found_by_edit is None
+        assert found_by_decrypt is None


### PR DESCRIPTION
## Summary
- Add `edit_token_prefix` and `decrypt_token_prefix` indexed columns to secrets table
- Store first 16 hex chars (64 bits) of each token for O(1) database lookup
- Update `find_secret_by_*_token()` to filter by prefix before Argon2 verification
- Create migration 0002 with backfill logic for existing secrets

## Performance Impact
- **Before**: O(N) database scan + O(N) Argon2 verifications per lookup (~100ms each)
- **After**: O(1) indexed query + O(1) Argon2 verification

With 10,000 secrets, worst-case lookup drops from ~16 minutes to milliseconds.

## Security Notes
- 64-bit prefix space makes collisions astronomically unlikely
- Full Argon2 hash verification still occurs after prefix lookup
- Attacker gains no advantage - they'd need to brute force prefix AND pass Argon2

## Test plan
- [x] Unit test for `get_token_prefix()` function
- [x] Test that `create_secret()` stores prefixes correctly
- [x] Test `find_secret_by_edit_token()` finds correct secret
- [x] Test `find_secret_by_decrypt_token()` finds correct secret
- [x] Test that deleted secrets are not returned
- [x] Migration test passes (`test_alembic_upgrade_head_on_fresh_sqlite_db`)
- [x] All 39 backend tests pass
- [x] `make check` passes

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)