### PR TITLE
security: remove unauthenticated /secrets/cleanup endpoint

### DIFF
--- a/backend/app/routers/secrets.py
+++ b/backend/app/routers/secrets.py
@@ -21,7 +21,6 @@ from app.services.pow_service import (
     validate_pow,
 )
 from app.services.secret_service import (
-    clear_expired_secrets,
     create_secret,
     find_secret_by_decrypt_token,
     find_secret_by_edit_token,
@@ -244,22 +243,3 @@ async def get_edit_status(
 
     status = get_secret_status(db, secret)
     return SecretStatusResponse(**status)
-
-
-@router.post("/secrets/cleanup")
-@limiter.limit("1/minute")
-async def trigger_cleanup(
-    request: Request,
-    db: Session = Depends(get_db),
-):
-    """
-    Manually trigger cleanup of expired and retrieved secrets.
-
-    Clears ciphertext/iv/auth_tag while preserving metadata for analytics.
-    Rate-limited to 1 request per minute.
-    """
-    cleared = clear_expired_secrets(db)
-
-    return {
-        "cleared": cleared,
-    }


### PR DESCRIPTION
## Summary
- Removed the unauthenticated `POST /api/v1/secrets/cleanup` endpoint
- Removed unused `clear_expired_secrets` import from router
- Background scheduler in `scheduler.py` already handles cleanup every hour

## Test plan
- [x] All backend tests pass (39 tests)
- [x] All frontend tests pass (63 tests)
- [x] `make check` passes

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)