### PR TITLE
chore: add scheduled cleanup for expired PoW challenges

### DIFF
--- a/backend/app/scheduler.py
+++ b/backend/app/scheduler.py
@@ -7,6 +7,7 @@ from apscheduler.triggers.interval import IntervalTrigger
 
 from app.config import settings
 from app.database import SessionLocal
+from app.services.pow_service import cleanup_expired_challenges
 from app.services.secret_service import clear_expired_secrets
 
 logger = logging.getLogger(__name__)
@@ -14,15 +15,28 @@ logger = logging.getLogger(__name__)
 scheduler = BackgroundScheduler()
 
 
-def cleanup_job() -> None:
+def cleanup_secrets_job() -> None:
     """Run periodic cleanup of expired and retrieved secrets."""
     db = SessionLocal()
     try:
         cleared = clear_expired_secrets(db)
         if cleared:
-            logger.info(f"Cleanup: cleared {cleared} secrets")
+            logger.info(f"Secrets cleanup: cleared {cleared} secrets")
     except Exception as e:
-        logger.error(f"Cleanup failed: {e}")
+        logger.error(f"Secrets cleanup failed: {e}")
+    finally:
+        db.close()
+
+
+def cleanup_challenges_job() -> None:
+    """Run periodic cleanup of expired PoW challenges."""
+    db = SessionLocal()
+    try:
+        deleted = cleanup_expired_challenges(db)
+        if deleted:
+            logger.info(f"Challenges cleanup: deleted {deleted} expired challenges")
+    except Exception as e:
+        logger.error(f"Challenges cleanup failed: {e}")
     finally:
         db.close()
 
@@ -30,9 +44,15 @@ def cleanup_job() -> None:
 def start_scheduler() -> None:
     """Start the background scheduler."""
     scheduler.add_job(
-        cleanup_job,
+        cleanup_secrets_job,
         trigger=IntervalTrigger(hours=settings.cleanup_interval_hours),
         id="cleanup_expired_secrets",
+        replace_existing=True,
+    )
+    scheduler.add_job(
+        cleanup_challenges_job,
+        trigger=IntervalTrigger(hours=settings.cleanup_interval_hours),
+        id="cleanup_expired_challenges",
         replace_existing=True,
     )
     scheduler.start()

--- a/backend/tests/test_pow_service.py
+++ b/backend/tests/test_pow_service.py
@@ -1,0 +1,93 @@
+"""Tests for the PoW service functions."""
+
+from datetime import timedelta
+
+import pytest
+
+from app.models.challenge import Challenge
+from app.services.pow_service import cleanup_expired_challenges, generate_challenge
+from tests.test_utils import utcnow
+
+
+@pytest.fixture
+def sample_payload_hash():
+    """Generate a sample payload hash for testing."""
+    return "a" * 64
+
+
+class TestCleanupExpiredChallenges:
+    """Tests for the cleanup_expired_challenges function."""
+
+    def test_cleanup_expired_challenges(self, db_session, sample_payload_hash):
+        """Test that expired challenges are deleted."""
+        # Create an expired challenge
+        challenge = generate_challenge(db_session, sample_payload_hash, 100)
+
+        # Manually set expires_at to the past
+        challenge.expires_at = utcnow() - timedelta(minutes=10)
+        db_session.commit()
+
+        # Verify it exists
+        assert db_session.query(Challenge).filter(Challenge.id == challenge.id).first() is not None
+
+        # Run cleanup
+        deleted_count = cleanup_expired_challenges(db_session)
+
+        # Verify it was deleted
+        assert deleted_count == 1
+        assert db_session.query(Challenge).filter(Challenge.id == challenge.id).first() is None
+
+    def test_cleanup_does_not_delete_valid_challenges(self, db_session, sample_payload_hash):
+        """Test that non-expired challenges are not deleted."""
+        # Create a valid (non-expired) challenge
+        challenge = generate_challenge(db_session, sample_payload_hash, 100)
+
+        # Verify it exists and is not expired
+        assert db_session.query(Challenge).filter(Challenge.id == challenge.id).first() is not None
+        assert challenge.expires_at > utcnow()
+
+        # Run cleanup
+        deleted_count = cleanup_expired_challenges(db_session)
+
+        # Verify it was not deleted
+        assert deleted_count == 0
+        assert db_session.query(Challenge).filter(Challenge.id == challenge.id).first() is not None
+
+    def test_cleanup_mixed_challenges(self, db_session, sample_payload_hash):
+        """Test cleanup with both expired and valid challenges."""
+        # Create valid challenge
+        valid_challenge = generate_challenge(db_session, sample_payload_hash, 100)
+        valid_challenge_id = valid_challenge.id
+
+        # Create expired challenge (need different payload hash for unique nonce)
+        expired_challenge = generate_challenge(db_session, "b" * 64, 100)
+        expired_challenge_id = expired_challenge.id
+        expired_challenge.expires_at = utcnow() - timedelta(minutes=10)
+        db_session.commit()
+
+        # Run cleanup
+        deleted_count = cleanup_expired_challenges(db_session)
+
+        # Verify only expired was deleted
+        assert deleted_count == 1
+        assert (
+            db_session.query(Challenge).filter(Challenge.id == valid_challenge_id).first()
+            is not None
+        )
+        assert (
+            db_session.query(Challenge).filter(Challenge.id == expired_challenge_id).first() is None
+        )
+
+    def test_cleanup_used_but_not_expired_challenges_remain(self, db_session, sample_payload_hash):
+        """Test that used but not expired challenges are not deleted."""
+        # Create a used but not expired challenge
+        challenge = generate_challenge(db_session, sample_payload_hash, 100)
+        challenge.is_used = True
+        db_session.commit()
+
+        # Run cleanup
+        deleted_count = cleanup_expired_challenges(db_session)
+
+        # Verify it was not deleted (cleanup only targets expired, not used)
+        assert deleted_count == 0
+        assert db_session.query(Challenge).filter(Challenge.id == challenge.id).first() is not None


### PR DESCRIPTION
## Summary
- Added `cleanup_challenges_job()` to scheduler alongside existing secrets cleanup
- Renamed `cleanup_job()` to `cleanup_secrets_job()` for clarity
- Both cleanup jobs run on the same hourly interval (`cleanup_interval_hours`)
- Added 4 tests for `cleanup_expired_challenges()` function

## Test plan
- [x] All backend tests pass (43 tests, +4 new)
- [x] All frontend tests pass (63 tests)
- [x] `make check` passes

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)