### PR TITLE
fix: distinguish expired vs retrieved on 410 from /secrets/retrieve

### DIFF
--- a/backend/app/routers/secrets.py
+++ b/backend/app/routers/secrets.py
@@ -186,7 +186,13 @@ async def retrieve_secret_endpoint(
         )
 
     if result["status"] == "retrieved":
-        raise HTTPException(status_code=410, detail=result["message"])
+        raise HTTPException(
+            status_code=410,
+            detail={
+                "status": "retrieved",
+                "message": result["message"],
+            },
+        )
 
     if result["status"] == "expired":
         raise HTTPException(

--- a/frontend/src/services/api.test.ts
+++ b/frontend/src/services/api.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { retrieveSecret } from './api'
+
+describe('retrieveSecret', () => {
+  const mockFetch = vi.fn()
+  const originalFetch = globalThis.fetch
+
+  beforeEach(() => {
+    globalThis.fetch = mockFetch
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    vi.resetAllMocks()
+  })
+
+  it('returns expired status when backend returns 410 with status=expired', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 410,
+      json: async () => ({
+        detail: {
+          status: 'expired',
+          expires_at: '2024-01-15T12:00:00Z',
+          message: 'This secret has expired and is no longer available',
+        },
+      }),
+    })
+
+    const result = await retrieveSecret('test-token')
+
+    expect(result.status).toBe('expired')
+    expect(result.expires_at).toBe('2024-01-15T12:00:00Z')
+    expect(result.message).toBe('This secret has expired and is no longer available')
+  })
+
+  it('returns retrieved status when backend returns 410 with status=retrieved', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 410,
+      json: async () => ({
+        detail: {
+          status: 'retrieved',
+          message: 'This secret has already been viewed',
+        },
+      }),
+    })
+
+    const result = await retrieveSecret('test-token')
+
+    expect(result.status).toBe('retrieved')
+    expect(result.message).toBe('This secret has already been viewed')
+  })
+
+  it('returns retrieved status with default message when 410 has no detail', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 410,
+      json: async () => ({}),
+    })
+
+    const result = await retrieveSecret('test-token')
+
+    expect(result.status).toBe('retrieved')
+    expect(result.message).toBe('This secret has already been retrieved')
+  })
+
+  it('returns pending status when backend returns 403', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      json: async () => ({
+        detail: {
+          status: 'pending',
+          unlock_at: '2024-12-31T23:59:59Z',
+          message: 'Secret not yet available',
+        },
+      }),
+    })
+
+    const result = await retrieveSecret('test-token')
+
+    expect(result.status).toBe('pending')
+    expect(result.unlock_at).toBe('2024-12-31T23:59:59Z')
+    expect(result.message).toBe('Secret not yet available')
+  })
+
+  it('returns secret data on successful retrieval', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        status: 'available',
+        ciphertext: 'encrypted-data',
+        iv: 'iv-data',
+        auth_tag: 'auth-tag-data',
+      }),
+    })
+
+    const result = await retrieveSecret('test-token')
+
+    expect(result.status).toBe('available')
+    expect(result.ciphertext).toBe('encrypted-data')
+    expect(result.iv).toBe('iv-data')
+    expect(result.auth_tag).toBe('auth-tag-data')
+  })
+})

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -114,11 +114,24 @@ export async function retrieveSecret(decryptToken: string): Promise<SecretRetrie
     }
   }
 
-  // Handle 410 (already retrieved)
+  // Handle 410 (already retrieved or expired)
   if (response.status === 410) {
+    const data = await response.json()
+    const detail = data.detail
+
+    // Check if it's an expired secret
+    if (detail?.status === 'expired') {
+      return {
+        status: 'expired',
+        expires_at: detail.expires_at,
+        message: detail.message || 'This secret has expired',
+      }
+    }
+
+    // Default to retrieved
     return {
       status: 'retrieved',
-      message: 'This secret has already been retrieved',
+      message: detail?.message || 'This secret has already been retrieved',
     }
   }
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -44,6 +44,7 @@ export interface SecretRetrieveResponse {
   iv?: string
   auth_tag?: string
   unlock_at?: string
+  expires_at?: string
   retrieved_at?: string
   message?: string
 }


### PR DESCRIPTION
## Summary
- Backend now returns structured JSON for 410 "retrieved" response (matching expired format)
- Frontend parses 410 response body to distinguish `expired` vs `retrieved` status
- Added `expires_at` field to `SecretRetrieveResponse` type
- Added 5 new frontend tests for `retrieveSecret()` behavior

## Test plan
- [x] All backend tests pass (43 tests)
- [x] All frontend tests pass (68 tests, +5 new)
- [x] `make check` passes

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)