### PR TITLE
docs: 'make test' runs both backend+frontend tests, but docs say backend-only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 ## Development Commands
 - `make dev` - Run both frontend and backend
-- `make test` - Run backend tests
+- `make test` - Run all tests (backend + frontend)
 - `make lint` - Lint both frontend and backend
 - `make format` - Format code
 - `make typecheck` - TypeScript type checking

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ The frontend calls the backend API at `${VITE_API_URL}/api/v1` (in production it
 
 ```bash
 make help          # Show all available commands
-make test          # Run backend tests
+make test          # Run all tests (backend + frontend)
 make lint          # Run linters for both backend and frontend
 make format        # Auto-format code
 make typecheck     # Run TypeScript type checking


### PR DESCRIPTION
## Summary

- Update README.md and CLAUDE.md to correctly state that `make test` runs both backend and frontend tests

Closes #78

## Test plan

- [x] `make check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)