### PR TITLE
docs: README project structure lists wrong frontend directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,8 +194,11 @@ RATE_LIMIT_RETRIEVES=30/minute
 │   ├── src/
 │   │   ├── components/  # React components
 │   │   ├── hooks/       # Custom React hooks
-│   │   ├── lib/         # Utilities and crypto
-│   │   └── types/       # TypeScript types
+│   │   ├── pages/       # Page components
+│   │   ├── services/    # API and crypto services
+│   │   ├── types/       # TypeScript types
+│   │   ├── utils/       # Utility functions
+│   │   └── workers/     # Web workers (PoW)
 │   ├── public/          # Static assets
 │   └── package.json     # Node dependencies
 ├── docs/                # Additional documentation


### PR DESCRIPTION
## Summary

- Fix frontend project structure to show actual directories
- Remove non-existent `lib/`
- Add `pages/`, `services/`, `utils/`, `workers/`

Closes #79

## Test plan

- [x] `make check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)