### PR TITLE
feat: Add version bump to promote-to-production workflow

### DIFF
--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -2,9 +2,18 @@ name: Promote to Production
 
 on:
   workflow_dispatch:
+    inputs:
+      version_bump:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        default: 'minor'
+        options:
+          - minor   # 0.1.0 -> 0.2.0 (project completion)
+          - patch   # 0.1.0 -> 0.1.1 (hotfix)
 
 permissions:
-  contents: read
+  contents: write
   actions: read
 
 jobs:
@@ -44,9 +53,54 @@ jobs:
           echo "- **Commit:** \`$commit_sha\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Message:** $commit_message" >> "$GITHUB_STEP_SUMMARY"
 
-  deploy_production:
+  bump_version:
     runs-on: ubuntu-latest
     needs: get_staging_tag
+    outputs:
+      new_version: ${{ steps.bump.outputs.new_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version
+        id: bump
+        working-directory: frontend
+        run: |
+          # Bump version (npm version updates package.json and creates a commit)
+          new_version=$(npm version ${{ inputs.version_bump }} --no-git-tag-version)
+          # Remove the 'v' prefix that npm adds
+          new_version="${new_version#v}"
+          echo "new_version=$new_version" >> "$GITHUB_OUTPUT"
+          echo "Bumped to version: $new_version"
+
+      - name: Commit and tag
+        run: |
+          version="${{ steps.bump.outputs.new_version }}"
+          git add frontend/package.json
+          git commit -m "chore: bump version to v${version}"
+          git tag "v${version}"
+          git push origin main --tags
+
+          echo "## Version Bump" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **New version:** v${version}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Bump type:** ${{ inputs.version_bump }}" >> "$GITHUB_STEP_SUMMARY"
+
+  deploy_production:
+    runs-on: ubuntu-latest
+    needs: [get_staging_tag, bump_version]
     environment: production
     steps:
       - name: Display deployment info
@@ -54,6 +108,7 @@ jobs:
           echo "## Production Deployment" >> "$GITHUB_STEP_SUMMARY"
           echo "Deploying **${{ needs.get_staging_tag.outputs.tag }}** to production" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Version:** v${{ needs.bump_version.outputs.new_version }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Commit:** \`${{ needs.get_staging_tag.outputs.commit_sha }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Message:** ${{ needs.get_staging_tag.outputs.commit_message }}" >> "$GITHUB_STEP_SUMMARY"
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.1.0-beta",
+  "version": "0.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Add version bump step to promote-to-production workflow
- Minor bump (default): for project completion (0.1.0 → 0.2.0)
- Patch bump: for hotfixes (0.1.0 → 0.1.1)
- Creates git tag (v0.x.y) on each production release
- Drop `-beta` suffix from version (0.x.y already signals pre-1.0)

Closes #60

## Test plan
- [x] `make check` passes
- [ ] Run workflow manually to verify version bump works

🤖 Generated with [Claude Code](https://claude.com/claude-code)