### PR TITLE
fix: Remove misleading updated_at from SecretEditResponse

### DIFF
--- a/backend/app/routers/secrets.py
+++ b/backend/app/routers/secrets.py
@@ -150,7 +150,6 @@ async def edit_secret(
         secret_id=updated_secret.id,
         unlock_at=updated_secret.unlock_at,
         expires_at=updated_secret.expires_at,
-        updated_at=updated_secret.unlock_at,  # Using unlock_at as proxy for updated_at
     )
 
 

--- a/backend/app/schemas/secret.py
+++ b/backend/app/schemas/secret.py
@@ -166,7 +166,6 @@ class SecretEditResponse(BaseModel):
     secret_id: str
     unlock_at: UTCDateTime
     expires_at: UTCDateTime
-    updated_at: UTCDateTime
 
 
 class SecretStatusResponse(BaseModel):

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -145,7 +145,7 @@ export async function updateSecretDates(
   editToken: string,
   newUnlockAt: string,
   newExpiresAt: string,
-): Promise<{ secret_id: string; unlock_at: string; expires_at: string; updated_at: string }> {
+): Promise<{ secret_id: string; unlock_at: string; expires_at: string }> {
   const response = await fetch(`${API_BASE}/secrets/edit`, {
     method: 'PUT',
     headers: {


### PR DESCRIPTION
## Summary

Remove the `updated_at` field from `SecretEditResponse` that was incorrectly using `unlock_at` as a proxy value.

## Problem

The code had a comment acknowledging the workaround:
```python
updated_at=updated_secret.unlock_at,  # Using unlock_at as proxy for updated_at
```

This was misleading for API consumers who might rely on `updated_at` for cache invalidation or audit trails.

## Solution

Since no client actually uses this field (verified the frontend ignores the response), remove it entirely rather than adding complexity with a new database column and migration.

## Changes

- `backend/app/schemas/secret.py`: Remove `updated_at` from `SecretEditResponse`
- `backend/app/routers/secrets.py`: Remove `updated_at` from response construction
- `frontend/src/services/api.ts`: Remove `updated_at` from return type

## Test plan

- [x] `make check` passes
- [x] Verified frontend doesn't use `updated_at` (it ignores the response)

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)