### PR TITLE
docs: remove ChatOps project from CLAUDE.md and AGENTS.md after completion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,6 @@
    - Active projects:
      - **#8** - IEOMD v0.2 - Payment Infrastructure (capability tokens, Lightning)
      - **#9** - IEOMD v0.3 - Premium Features (file uploads, edit content)
-     - **#10** - IEOMD - ChatOps & Notifications (feedback, alerts)
      - **#11** - IEOMD - UX Enhancements (link ordering, defaults, sharing)
 
 3. **Create a branch for the issue**


### PR DESCRIPTION
## Summary
- Removed project #10 (ChatOps & Notifications) from the active projects list in CLAUDE.md
- AGENTS.md did not reference project #10, so no changes needed there

All items in project #10 are now complete:
- ✅ Discord webhook alerts for scheduler failures (#109)
- ✅ Simple one-way feedback form (#131)
- ✅ Discord server setup (#132)
- ✅ Matrix research (#130)

## Test plan
- [x] Verify CLAUDE.md no longer references project #10
- [x] Verify no stale project references remain

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)