### PR TITLE
feat: Capability token model and API

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -22,3 +22,8 @@ RATE_LIMIT_RETRIEVES=30/minute
 # DISCORD_FEEDBACK_WEBHOOK_URL=https://discord.com/api/webhooks/...
 # DISCORD_ALERTS_WEBHOOK_URL=https://discord.com/api/webhooks/...
 # ^ Alerts webhook receives: 5xx errors, scheduler failures, rate limit violations
+
+# Capability Tokens (for premium features)
+# Set this to enable capability token creation via POST /api/v1/capability-tokens
+# Generate with: python -c "import secrets; print(secrets.token_hex(32))"
+# INTERNAL_API_KEY=your-secret-api-key-here

--- a/backend/alembic/versions/0003_add_capability_tokens.py
+++ b/backend/alembic/versions/0003_add_capability_tokens.py
@@ -1,0 +1,66 @@
+"""Add capability_tokens table
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2025-01-02
+
+Adds capability_tokens table for premium feature access tokens.
+Tokens are bearer instruments that bypass PoW and enable larger file uploads.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0003"
+down_revision: str | None = "0002"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "capability_tokens",
+        sa.Column("id", sa.String(36), primary_key=True),
+        sa.Column("token_prefix", sa.String(16), nullable=False),
+        sa.Column("token_hash", sa.String(128), unique=True, nullable=False),
+        sa.Column("tier", sa.String(20), nullable=False),
+        sa.Column("max_file_size_bytes", sa.Integer, nullable=False),
+        sa.Column("max_expiry_days", sa.Integer, nullable=False),
+        sa.Column("created_at", sa.DateTime, nullable=False),
+        sa.Column("expires_at", sa.DateTime, nullable=False),
+        sa.Column("consumed_at", sa.DateTime, nullable=True),
+        sa.Column(
+            "consumed_by_secret_id",
+            sa.String(36),
+            sa.ForeignKey("secrets.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("payment_provider", sa.String(50), nullable=True),
+        sa.Column("payment_reference", sa.String(255), nullable=True),
+    )
+
+    # Indexes
+    op.create_index("ix_capability_tokens_token_prefix", "capability_tokens", ["token_prefix"])
+    op.create_index("ix_capability_tokens_expires_at", "capability_tokens", ["expires_at"])
+    op.create_index(
+        "ix_capability_tokens_consumed_by_secret_id",
+        "capability_tokens",
+        ["consumed_by_secret_id"],
+    )
+    op.create_index(
+        "ix_capability_tokens_payment_reference",
+        "capability_tokens",
+        ["payment_reference"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_capability_tokens_payment_reference", table_name="capability_tokens")
+    op.drop_index("ix_capability_tokens_consumed_by_secret_id", table_name="capability_tokens")
+    op.drop_index("ix_capability_tokens_expires_at", table_name="capability_tokens")
+    op.drop_index("ix_capability_tokens_token_prefix", table_name="capability_tokens")
+    op.drop_table("capability_tokens")

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -46,5 +46,27 @@ class Settings(BaseSettings):
     # Rate Limiting - Feedback
     rate_limit_feedback: str = "5/minute"
 
+    # Capability Tokens
+    capability_tiers: dict = {
+        "basic": {
+            "max_file_size_bytes": 10_000_000,
+            "max_expiry_days": 365,
+            "price_sats": 1000,
+        },
+        "standard": {
+            "max_file_size_bytes": 100_000_000,
+            "max_expiry_days": 730,
+            "price_sats": 5000,
+        },
+        "large": {
+            "max_file_size_bytes": 500_000_000,
+            "max_expiry_days": 1825,
+            "price_sats": 20000,
+        },
+    }
+    rate_limit_token_create: str = "100/minute"
+    rate_limit_token_validate: str = "60/minute"
+    internal_api_key: str | None = None
+
 
 settings = Settings()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,7 +13,7 @@ from app.database import engine
 from app.logging_config import get_logger, setup_logging
 from app.middleware.logging import LoggingMiddleware
 from app.middleware.rate_limit import limiter
-from app.routers import challenges, feedback, secrets
+from app.routers import capability_tokens, challenges, feedback, secrets
 from app.scheduler import shutdown_scheduler, start_scheduler
 from app.services.discord_service import send_error_alert
 
@@ -32,7 +32,7 @@ def check_database_tables():
     Raises RuntimeError with helpful message if tables are missing.
     This helps catch the case where migrations haven't been run.
     """
-    required_tables = {"secrets", "pow_challenges"}
+    required_tables = {"secrets", "pow_challenges", "capability_tokens"}
     inspector = inspect(engine)
     existing_tables = set(inspector.get_table_names())
 
@@ -163,6 +163,7 @@ app.add_middleware(
 app.add_middleware(LoggingMiddleware)
 
 # Routers
+app.include_router(capability_tokens.router, prefix="/api/v1", tags=["capability-tokens"])
 app.include_router(challenges.router, prefix="/api/v1", tags=["challenges"])
 app.include_router(feedback.router, prefix="/api/v1", tags=["feedback"])
 app.include_router(secrets.router, prefix="/api/v1", tags=["secrets"])

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,4 +1,5 @@
+from app.models.capability_token import CapabilityToken
 from app.models.challenge import Challenge
 from app.models.secret import Secret
 
-__all__ = ["Secret", "Challenge"]
+__all__ = ["Secret", "Challenge", "CapabilityToken"]

--- a/backend/app/models/capability_token.py
+++ b/backend/app/models/capability_token.py
@@ -1,0 +1,54 @@
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class CapabilityToken(Base):
+    """
+    Capability token for premium features.
+
+    Tokens are bearer instruments that grant permission to create secrets
+    with premium features (e.g., file uploads, larger sizes). They bypass
+    the Proof-of-Work requirement.
+
+    Tokens are:
+    - Single-use: marked consumed after use
+    - Tier-based: different tiers unlock different features
+    - Payment-agnostic: created via webhook or manually, usable anonymously
+    """
+
+    __tablename__ = "capability_tokens"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+
+    # Token lookup (same pattern as secrets: prefix + hash)
+    token_prefix: Mapped[str] = mapped_column(String(16), index=True, nullable=False)
+    token_hash: Mapped[str] = mapped_column(String(128), unique=True, nullable=False)
+
+    # Tier and limits
+    tier: Mapped[str] = mapped_column(String(20), nullable=False)
+    max_file_size_bytes: Mapped[int] = mapped_column(Integer, nullable=False)
+    max_expiry_days: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    # Timestamps
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.now(UTC).replace(tzinfo=None), nullable=False
+    )
+    expires_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    consumed_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True, default=None)
+
+    # Consumption tracking
+    consumed_by_secret_id: Mapped[str | None] = mapped_column(
+        String(36),
+        ForeignKey("secrets.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+
+    # Payment tracking (for audit/reconciliation)
+    payment_provider: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    payment_reference: Mapped[str | None] = mapped_column(String(255), nullable=True, index=True)

--- a/backend/app/routers/capability_tokens.py
+++ b/backend/app/routers/capability_tokens.py
@@ -1,0 +1,87 @@
+import structlog
+from fastapi import APIRouter, Depends, Header, HTTPException, Request
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.database import get_db
+from app.middleware.rate_limit import limiter
+from app.schemas.capability_token import (
+    CapabilityTokenCreate,
+    CapabilityTokenCreateResponse,
+    CapabilityTokenValidateResponse,
+)
+from app.services.capability_token_service import (
+    create_capability_token,
+    validate_capability_token,
+)
+
+router = APIRouter()
+logger = structlog.get_logger()
+
+
+def verify_internal_api_key(x_api_key: str = Header(..., alias="X-API-Key")) -> None:
+    """Verify internal API key for token creation."""
+    if not settings.internal_api_key:
+        raise HTTPException(status_code=503, detail="Token creation not configured")
+    if x_api_key != settings.internal_api_key:
+        raise HTTPException(status_code=401, detail="Invalid API key")
+
+
+@router.post("/capability-tokens", response_model=CapabilityTokenCreateResponse, status_code=201)
+@limiter.limit(settings.rate_limit_token_create)
+async def create_token(
+    request: Request,
+    token_data: CapabilityTokenCreate,
+    db: Session = Depends(get_db),
+    _: None = Depends(verify_internal_api_key),
+):
+    """
+    Create a new capability token (internal endpoint).
+
+    Called by payment webhooks after successful payment, or manually for testing/promos.
+    Requires X-API-Key header with internal API key.
+    """
+    try:
+        token_model, raw_token = create_capability_token(
+            db=db,
+            tier=token_data.tier,
+            payment_provider=token_data.payment_provider,
+            payment_reference=token_data.payment_reference,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    logger.info(
+        "capability_token_created",
+        token_id=token_model.id,
+        tier=token_model.tier,
+        payment_provider=token_data.payment_provider,
+    )
+
+    return CapabilityTokenCreateResponse(
+        token=raw_token,
+        tier=token_model.tier,
+        max_file_size_bytes=token_model.max_file_size_bytes,
+        max_expiry_days=token_model.max_expiry_days,
+        expires_at=token_model.expires_at,
+    )
+
+
+@router.get("/capability-tokens/validate", response_model=CapabilityTokenValidateResponse)
+@limiter.limit(settings.rate_limit_token_validate)
+async def validate_token(
+    request: Request,
+    x_capability_token: str = Header(..., alias="X-Capability-Token"),
+    db: Session = Depends(get_db),
+):
+    """
+    Validate a capability token without consuming it.
+
+    Returns tier information if valid. Does not consume the token.
+    """
+    if len(x_capability_token) != 64:
+        return CapabilityTokenValidateResponse(valid=False, error="Invalid token format")
+
+    result = validate_capability_token(db, x_capability_token)
+
+    return CapabilityTokenValidateResponse(**result)

--- a/backend/app/schemas/capability_token.py
+++ b/backend/app/schemas/capability_token.py
@@ -1,0 +1,33 @@
+from pydantic import BaseModel, Field
+
+from app.schemas.secret import UTCDateTime
+
+
+class CapabilityTokenCreate(BaseModel):
+    """Internal request to create a capability token (from payment webhook or manual)."""
+
+    tier: str = Field(..., pattern="^(basic|standard|large)$")
+    payment_provider: str | None = None
+    payment_reference: str | None = None
+
+
+class CapabilityTokenCreateResponse(BaseModel):
+    """Response containing the raw token (only returned once at creation)."""
+
+    token: str  # Raw token - only returned at creation time
+    tier: str
+    max_file_size_bytes: int
+    max_expiry_days: int
+    expires_at: UTCDateTime
+
+
+class CapabilityTokenValidateResponse(BaseModel):
+    """Response for token validation (without consuming)."""
+
+    valid: bool
+    tier: str | None = None
+    max_file_size_bytes: int | None = None
+    max_expiry_days: int | None = None
+    expires_at: UTCDateTime | None = None
+    consumed: bool = False
+    error: str | None = None

--- a/backend/app/schemas/secret.py
+++ b/backend/app/schemas/secret.py
@@ -50,14 +50,14 @@ class SecretCreate(BaseModel):
     expires_at: datetime
     edit_token: str = Field(..., min_length=64, max_length=64, description="Hex token")
     decrypt_token: str = Field(..., min_length=64, max_length=64, description="Hex token")
-    pow_proof: PowProof
+    pow_proof: PowProof | None = None  # Optional when using capability token
 
     @field_validator("ciphertext")
     @classmethod
     def validate_ciphertext_base64(cls, v: str) -> str:
+        # Only validate base64 format here. Size validation is done in the router
+        # because the limit depends on whether PoW or capability token is used.
         decoded = strict_base64_decode(v, "ciphertext")
-        if len(decoded) > settings.max_ciphertext_size:
-            raise ValueError(f"Ciphertext exceeds {settings.max_ciphertext_size} bytes")
         if len(decoded) < 1:
             raise ValueError("Ciphertext cannot be empty")
         return v

--- a/backend/app/services/capability_token_service.py
+++ b/backend/app/services/capability_token_service.py
@@ -1,0 +1,137 @@
+import secrets
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.models.capability_token import CapabilityToken
+from app.services.crypto_utils import hash_token, verify_token
+
+TOKEN_PREFIX_LENGTH = 16
+
+
+def get_token_prefix(token: str) -> str:
+    """Extract the prefix from a token for indexed lookup."""
+    return token[:TOKEN_PREFIX_LENGTH]
+
+
+def get_tier_config(tier: str) -> dict | None:
+    """Get configuration for a tier."""
+    return settings.capability_tiers.get(tier)
+
+
+def create_capability_token(
+    db: Session,
+    tier: str,
+    payment_provider: str | None = None,
+    payment_reference: str | None = None,
+) -> tuple[CapabilityToken, str]:
+    """
+    Create a new capability token.
+
+    Returns tuple of (token_model, raw_token).
+    The raw_token is only available at creation time.
+    """
+    tier_config = get_tier_config(tier)
+    if not tier_config:
+        raise ValueError(f"Invalid tier: {tier}")
+
+    # Generate secure random token (64 hex chars = 256 bits)
+    raw_token = secrets.token_hex(32)
+
+    # Token expires 5 years from creation - user can use whenever ready
+    expires_at = datetime.now(UTC).replace(tzinfo=None) + timedelta(days=5 * 365)
+
+    token = CapabilityToken(
+        token_prefix=get_token_prefix(raw_token),
+        token_hash=hash_token(raw_token),
+        tier=tier,
+        max_file_size_bytes=tier_config["max_file_size_bytes"],
+        max_expiry_days=tier_config["max_expiry_days"],
+        expires_at=expires_at,
+        payment_provider=payment_provider,
+        payment_reference=payment_reference,
+    )
+
+    db.add(token)
+    db.commit()
+    db.refresh(token)
+
+    return token, raw_token
+
+
+def find_capability_token(db: Session, raw_token: str) -> CapabilityToken | None:
+    """
+    Find a capability token by its raw value.
+
+    Uses indexed prefix lookup, then Argon2 verification.
+    Returns None if not found or already consumed.
+    """
+    prefix = get_token_prefix(raw_token)
+    candidates = (
+        db.query(CapabilityToken)
+        .filter(
+            CapabilityToken.token_prefix == prefix,
+            CapabilityToken.consumed_at == None,  # noqa: E711 - SQLAlchemy requires ==
+        )
+        .all()
+    )
+
+    for token in candidates:
+        if verify_token(raw_token, token.token_hash):
+            return token
+
+    return None
+
+
+def validate_capability_token(db: Session, raw_token: str) -> dict:
+    """
+    Validate a capability token without consuming it.
+
+    Returns dict with validation result and tier info.
+    """
+    token = find_capability_token(db, raw_token)
+
+    if token is None:
+        # Check if it was already consumed
+        prefix = get_token_prefix(raw_token)
+        consumed_candidates = (
+            db.query(CapabilityToken)
+            .filter(
+                CapabilityToken.token_prefix == prefix,
+                CapabilityToken.consumed_at != None,  # noqa: E711
+            )
+            .all()
+        )
+        for consumed in consumed_candidates:
+            if verify_token(raw_token, consumed.token_hash):
+                return {"valid": False, "consumed": True, "error": "Token already consumed"}
+        return {"valid": False, "error": "Token not found"}
+
+    now = datetime.now(UTC).replace(tzinfo=None)
+    if now >= token.expires_at:
+        return {"valid": False, "error": "Token expired"}
+
+    return {
+        "valid": True,
+        "tier": token.tier,
+        "max_file_size_bytes": token.max_file_size_bytes,
+        "max_expiry_days": token.max_expiry_days,
+        "expires_at": token.expires_at,
+        "consumed": False,
+    }
+
+
+def consume_capability_token(
+    db: Session,
+    token: CapabilityToken,
+    secret_id: str,
+) -> None:
+    """
+    Mark a capability token as consumed.
+
+    Called after successful secret creation.
+    """
+    token.consumed_at = datetime.now(UTC).replace(tzinfo=None)
+    token.consumed_by_secret_id = secret_id
+    db.commit()

--- a/backend/tests/test_capability_tokens.py
+++ b/backend/tests/test_capability_tokens.py
@@ -1,0 +1,475 @@
+"""Comprehensive tests for capability tokens."""
+
+import base64
+import secrets
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+from app.config import settings
+from app.services.capability_token_service import (
+    consume_capability_token,
+    create_capability_token,
+    find_capability_token,
+    validate_capability_token,
+)
+
+
+def generate_test_data(size: int = 100):
+    """Generate test cryptographic data."""
+    iv = secrets.token_bytes(12)
+    auth_tag = secrets.token_bytes(16)
+    ciphertext = secrets.token_bytes(size)
+    edit_token = secrets.token_hex(32)
+    decrypt_token = secrets.token_hex(32)
+
+    return {
+        "ciphertext": base64.b64encode(ciphertext).decode(),
+        "iv": base64.b64encode(iv).decode(),
+        "auth_tag": base64.b64encode(auth_tag).decode(),
+        "edit_token": edit_token,
+        "decrypt_token": decrypt_token,
+    }
+
+
+class TestCapabilityTokenCreation:
+    """Tests for capability token creation endpoint."""
+
+    def test_create_token_valid_tier(self, client, db_session):
+        """Test creating a token with valid tier."""
+        with patch.object(settings, "internal_api_key", "test-api-key"):
+            response = client.post(
+                "/api/v1/capability-tokens",
+                json={"tier": "basic"},
+                headers={"X-API-Key": "test-api-key"},
+            )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert "token" in data
+        assert len(data["token"]) == 64  # 32 bytes as hex
+        assert data["tier"] == "basic"
+        assert data["max_file_size_bytes"] == 10_000_000
+        assert data["max_expiry_days"] == 365
+        assert "expires_at" in data
+
+    def test_create_token_all_tiers(self, client, db_session):
+        """Test creating tokens for all valid tiers."""
+        tiers = ["basic", "standard", "large"]
+        expected_sizes = [10_000_000, 100_000_000, 500_000_000]
+
+        with patch.object(settings, "internal_api_key", "test-api-key"):
+            for tier, expected_size in zip(tiers, expected_sizes):
+                response = client.post(
+                    "/api/v1/capability-tokens",
+                    json={"tier": tier},
+                    headers={"X-API-Key": "test-api-key"},
+                )
+                assert response.status_code == 201
+                assert response.json()["max_file_size_bytes"] == expected_size
+
+    def test_create_token_invalid_tier(self, client, db_session):
+        """Test creating a token with invalid tier."""
+        with patch.object(settings, "internal_api_key", "test-api-key"):
+            response = client.post(
+                "/api/v1/capability-tokens",
+                json={"tier": "premium"},  # Invalid tier
+                headers={"X-API-Key": "test-api-key"},
+            )
+
+        assert response.status_code == 422  # Validation error from Pydantic
+
+    def test_create_token_missing_api_key(self, client, db_session):
+        """Test creating a token without API key."""
+        with patch.object(settings, "internal_api_key", "test-api-key"):
+            response = client.post(
+                "/api/v1/capability-tokens",
+                json={"tier": "basic"},
+            )
+
+        assert response.status_code == 422  # Missing required header
+
+    def test_create_token_wrong_api_key(self, client, db_session):
+        """Test creating a token with wrong API key."""
+        with patch.object(settings, "internal_api_key", "test-api-key"):
+            response = client.post(
+                "/api/v1/capability-tokens",
+                json={"tier": "basic"},
+                headers={"X-API-Key": "wrong-key"},
+            )
+
+        assert response.status_code == 401
+        assert "Invalid API key" in response.json()["detail"]
+
+    def test_create_token_not_configured(self, client, db_session):
+        """Test creating a token when API key is not configured."""
+        with patch.object(settings, "internal_api_key", None):
+            response = client.post(
+                "/api/v1/capability-tokens",
+                json={"tier": "basic"},
+                headers={"X-API-Key": "any-key"},
+            )
+
+        assert response.status_code == 503
+        assert "not configured" in response.json()["detail"]
+
+    def test_create_token_with_payment_info(self, client, db_session):
+        """Test creating a token with payment information."""
+        with patch.object(settings, "internal_api_key", "test-api-key"):
+            response = client.post(
+                "/api/v1/capability-tokens",
+                json={
+                    "tier": "standard",
+                    "payment_provider": "lightning",
+                    "payment_reference": "inv_123456",
+                },
+                headers={"X-API-Key": "test-api-key"},
+            )
+
+        assert response.status_code == 201
+
+        # Verify payment info is stored
+        token_data = response.json()
+        token = find_capability_token(db_session, token_data["token"])
+        assert token.payment_provider == "lightning"
+        assert token.payment_reference == "inv_123456"
+
+
+class TestCapabilityTokenValidation:
+    """Tests for capability token validation endpoint."""
+
+    def test_validate_valid_token(self, client, db_session):
+        """Test validating a valid token."""
+        # Create a token directly
+        token_model, raw_token = create_capability_token(db_session, "basic")
+
+        response = client.get(
+            "/api/v1/capability-tokens/validate",
+            headers={"X-Capability-Token": raw_token},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["valid"] is True
+        assert data["tier"] == "basic"
+        assert data["max_file_size_bytes"] == 10_000_000
+        assert data["consumed"] is False
+
+    def test_validate_invalid_token(self, client, db_session):
+        """Test validating an invalid token."""
+        response = client.get(
+            "/api/v1/capability-tokens/validate",
+            headers={"X-Capability-Token": secrets.token_hex(32)},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["valid"] is False
+        assert data["error"] == "Token not found"
+
+    def test_validate_consumed_token(self, client, db_session):
+        """Test validating a consumed token."""
+        token_model, raw_token = create_capability_token(db_session, "basic")
+        consume_capability_token(db_session, token_model, "fake-secret-id")
+
+        response = client.get(
+            "/api/v1/capability-tokens/validate",
+            headers={"X-Capability-Token": raw_token},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["valid"] is False
+        assert data["consumed"] is True
+        assert "already consumed" in data["error"]
+
+    def test_validate_expired_token(self, client, db_session):
+        """Test validating an expired token."""
+        token_model, raw_token = create_capability_token(db_session, "basic")
+        # Manually expire the token
+        token_model.expires_at = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=1)
+        db_session.commit()
+
+        response = client.get(
+            "/api/v1/capability-tokens/validate",
+            headers={"X-Capability-Token": raw_token},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["valid"] is False
+        assert "expired" in data["error"]
+
+    def test_validate_invalid_format(self, client, db_session):
+        """Test validating a token with invalid format."""
+        response = client.get(
+            "/api/v1/capability-tokens/validate",
+            headers={"X-Capability-Token": "too-short"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["valid"] is False
+        assert "Invalid token format" in data["error"]
+
+
+class TestSecretCreationWithToken:
+    """Tests for secret creation using capability tokens."""
+
+    def test_create_secret_with_token(self, client, db_session):
+        """Test creating a secret with a capability token (bypasses PoW)."""
+        token_model, raw_token = create_capability_token(db_session, "basic")
+        test_data = generate_test_data()
+
+        unlock_at = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+        expires_at = (datetime.now(UTC) + timedelta(days=30)).isoformat()
+
+        response = client.post(
+            "/api/v1/secrets",
+            json={
+                "ciphertext": test_data["ciphertext"],
+                "iv": test_data["iv"],
+                "auth_tag": test_data["auth_tag"],
+                "edit_token": test_data["edit_token"],
+                "decrypt_token": test_data["decrypt_token"],
+                "unlock_at": unlock_at,
+                "expires_at": expires_at,
+                # No pow_proof!
+            },
+            headers={"X-Capability-Token": raw_token},
+        )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert "secret_id" in data
+
+        # Verify token is consumed
+        db_session.refresh(token_model)
+        assert token_model.consumed_at is not None
+        assert token_model.consumed_by_secret_id == data["secret_id"]
+
+    def test_create_secret_token_consumed_only_once(self, client, db_session):
+        """Test that a token can only be used once."""
+        token_model, raw_token = create_capability_token(db_session, "basic")
+        test_data = generate_test_data()
+
+        unlock_at = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+        expires_at = (datetime.now(UTC) + timedelta(days=30)).isoformat()
+
+        # First creation should succeed
+        response1 = client.post(
+            "/api/v1/secrets",
+            json={
+                "ciphertext": test_data["ciphertext"],
+                "iv": test_data["iv"],
+                "auth_tag": test_data["auth_tag"],
+                "edit_token": test_data["edit_token"],
+                "decrypt_token": test_data["decrypt_token"],
+                "unlock_at": unlock_at,
+                "expires_at": expires_at,
+            },
+            headers={"X-Capability-Token": raw_token},
+        )
+        assert response1.status_code == 201
+
+        # Generate new tokens for second attempt
+        test_data2 = generate_test_data()
+
+        # Second creation with same token should fail
+        response2 = client.post(
+            "/api/v1/secrets",
+            json={
+                "ciphertext": test_data2["ciphertext"],
+                "iv": test_data2["iv"],
+                "auth_tag": test_data2["auth_tag"],
+                "edit_token": test_data2["edit_token"],
+                "decrypt_token": test_data2["decrypt_token"],
+                "unlock_at": unlock_at,
+                "expires_at": expires_at,
+            },
+            headers={"X-Capability-Token": raw_token},
+        )
+        assert response2.status_code == 401
+        assert "Invalid or consumed" in response2.json()["detail"]
+
+    def test_create_secret_size_limit_enforced(self, client, db_session):
+        """Test that file size limits are enforced per tier."""
+        # Create a basic tier token (10MB limit)
+        token_model, raw_token = create_capability_token(db_session, "basic")
+
+        # Generate data larger than 10MB (using 15MB)
+        test_data = generate_test_data(size=15_000_000)
+
+        unlock_at = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+        expires_at = (datetime.now(UTC) + timedelta(days=30)).isoformat()
+
+        response = client.post(
+            "/api/v1/secrets",
+            json={
+                "ciphertext": test_data["ciphertext"],
+                "iv": test_data["iv"],
+                "auth_tag": test_data["auth_tag"],
+                "edit_token": test_data["edit_token"],
+                "decrypt_token": test_data["decrypt_token"],
+                "unlock_at": unlock_at,
+                "expires_at": expires_at,
+            },
+            headers={"X-Capability-Token": raw_token},
+        )
+
+        assert response.status_code == 400
+        assert "exceeds token limit" in response.json()["detail"]
+
+        # Verify token is NOT consumed on failure
+        db_session.refresh(token_model)
+        assert token_model.consumed_at is None
+
+    def test_create_secret_expired_token(self, client, db_session):
+        """Test creating a secret with an expired token."""
+        token_model, raw_token = create_capability_token(db_session, "basic")
+        # Manually expire the token
+        token_model.expires_at = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=1)
+        db_session.commit()
+
+        test_data = generate_test_data()
+        unlock_at = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+        expires_at = (datetime.now(UTC) + timedelta(days=30)).isoformat()
+
+        response = client.post(
+            "/api/v1/secrets",
+            json={
+                "ciphertext": test_data["ciphertext"],
+                "iv": test_data["iv"],
+                "auth_tag": test_data["auth_tag"],
+                "edit_token": test_data["edit_token"],
+                "decrypt_token": test_data["decrypt_token"],
+                "unlock_at": unlock_at,
+                "expires_at": expires_at,
+            },
+            headers={"X-Capability-Token": raw_token},
+        )
+
+        assert response.status_code == 401
+        assert "expired" in response.json()["detail"]
+
+    def test_create_secret_invalid_token_format(self, client, db_session):
+        """Test creating a secret with invalid token format."""
+        test_data = generate_test_data()
+        unlock_at = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+        expires_at = (datetime.now(UTC) + timedelta(days=30)).isoformat()
+
+        response = client.post(
+            "/api/v1/secrets",
+            json={
+                "ciphertext": test_data["ciphertext"],
+                "iv": test_data["iv"],
+                "auth_tag": test_data["auth_tag"],
+                "edit_token": test_data["edit_token"],
+                "decrypt_token": test_data["decrypt_token"],
+                "unlock_at": unlock_at,
+                "expires_at": expires_at,
+            },
+            headers={"X-Capability-Token": "invalid-short-token"},
+        )
+
+        assert response.status_code == 400
+        assert "Invalid capability token format" in response.json()["detail"]
+
+    def test_create_secret_requires_pow_or_token(self, client, db_session):
+        """Test that either PoW or capability token is required."""
+        test_data = generate_test_data()
+        unlock_at = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+        expires_at = (datetime.now(UTC) + timedelta(days=30)).isoformat()
+
+        response = client.post(
+            "/api/v1/secrets",
+            json={
+                "ciphertext": test_data["ciphertext"],
+                "iv": test_data["iv"],
+                "auth_tag": test_data["auth_tag"],
+                "edit_token": test_data["edit_token"],
+                "decrypt_token": test_data["decrypt_token"],
+                "unlock_at": unlock_at,
+                "expires_at": expires_at,
+                # No pow_proof and no X-Capability-Token header
+            },
+        )
+
+        assert response.status_code == 400
+        assert "pow_proof or X-Capability-Token" in response.json()["detail"]
+
+    def test_create_secret_token_not_consumed_on_validation_failure(self, client, db_session):
+        """Test that token is not consumed when other validations fail."""
+        token_model, raw_token = create_capability_token(db_session, "basic")
+        test_data = generate_test_data()
+
+        # Invalid dates (expires_at before unlock_at)
+        unlock_at = (datetime.now(UTC) + timedelta(days=30)).isoformat()
+        expires_at = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+
+        response = client.post(
+            "/api/v1/secrets",
+            json={
+                "ciphertext": test_data["ciphertext"],
+                "iv": test_data["iv"],
+                "auth_tag": test_data["auth_tag"],
+                "edit_token": test_data["edit_token"],
+                "decrypt_token": test_data["decrypt_token"],
+                "unlock_at": unlock_at,
+                "expires_at": expires_at,
+            },
+            headers={"X-Capability-Token": raw_token},
+        )
+
+        assert response.status_code == 422  # Validation error
+
+        # Verify token is NOT consumed
+        db_session.refresh(token_model)
+        assert token_model.consumed_at is None
+
+
+class TestCapabilityTokenService:
+    """Direct tests for capability token service functions."""
+
+    def test_create_and_find_token(self, db_session):
+        """Test creating and finding a token."""
+        token_model, raw_token = create_capability_token(db_session, "standard")
+
+        assert token_model.tier == "standard"
+        assert token_model.max_file_size_bytes == 100_000_000
+
+        found = find_capability_token(db_session, raw_token)
+        assert found is not None
+        assert found.id == token_model.id
+
+    def test_find_nonexistent_token(self, db_session):
+        """Test finding a token that doesn't exist."""
+        found = find_capability_token(db_session, secrets.token_hex(32))
+        assert found is None
+
+    def test_validate_token_result(self, db_session):
+        """Test validate_capability_token result structure."""
+        token_model, raw_token = create_capability_token(db_session, "large")
+
+        result = validate_capability_token(db_session, raw_token)
+
+        assert result["valid"] is True
+        assert result["tier"] == "large"
+        assert result["max_file_size_bytes"] == 500_000_000
+        assert result["max_expiry_days"] == 1825
+        assert result["consumed"] is False
+
+    def test_consume_token(self, db_session):
+        """Test consuming a token."""
+        token_model, raw_token = create_capability_token(db_session, "basic")
+
+        assert token_model.consumed_at is None
+        assert token_model.consumed_by_secret_id is None
+
+        consume_capability_token(db_session, token_model, "test-secret-id")
+
+        assert token_model.consumed_at is not None
+        assert token_model.consumed_by_secret_id == "test-secret-id"
+
+        # Should not be findable anymore
+        found = find_capability_token(db_session, raw_token)
+        assert found is None


### PR DESCRIPTION
## Summary
- Implements capability tokens as bearer instruments that bypass Proof-of-Work
- Enables premium features: file uploads up to 500MB based on tier
- Tokens are single-use, tier-based, and payment-agnostic

## Changes
- New `CapabilityToken` model with migration
- Token creation endpoint (`POST /capability-tokens` - internal, requires API key)
- Token validation endpoint (`GET /capability-tokens/validate`)
- Modified `POST /secrets` to accept `X-Capability-Token` header as PoW alternative
- Comprehensive tests (22 new test cases)

## Tiers
| Tier | Max File Size | Max Expiry |
|------|---------------|------------|
| basic | 10 MB | 1 year |
| standard | 100 MB | 2 years |
| large | 500 MB | 5 years |

## Usage
Create a token (internal):
\`\`\`bash
curl -X POST /api/v1/capability-tokens \
  -H "X-API-Key: \$INTERNAL_API_KEY" \
  -d '{"tier": "basic"}'
\`\`\`

Use token to create secret:
\`\`\`bash
curl -X POST /api/v1/secrets \
  -H "X-Capability-Token: <token>" \
  -d '{"ciphertext": "...", ...}'
\`\`\`

## Test plan
- [x] Token creation with valid/invalid tiers
- [x] Token validation (valid, consumed, expired)
- [x] Secret creation with token bypasses PoW
- [x] Size limits enforced per tier
- [x] Token consumed only after successful secret creation
- [x] All existing tests still pass

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)