### PR TITLE
fix: pass INTERNAL_API_KEY to production during deploy

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -32,7 +32,7 @@ jobs:
           backend="ghcr.io/${GITHUB_REPOSITORY_OWNER}/in-the-event-of-my-death-backend:${{ inputs.tag }}"
           web="ghcr.io/${GITHUB_REPOSITORY_OWNER}/in-the-event-of-my-death-web:${{ inputs.tag }}"
           ssh -o BatchMode=yes -o ConnectTimeout=10 "${{ secrets.PROD_SSH_USER }}@${{ secrets.PROD_SSH_HOST }}" \
-            "INTERNAL_API_KEY='${{ secrets.INTERNAL_API_KEY }}' sudo -E /usr/local/bin/ieomd-deploy deploy --dir /opt/ieomd --backend-image ${backend} --web-image ${web}"
+            "sudo INTERNAL_API_KEY='${{ secrets.INTERNAL_API_KEY }}' /usr/local/bin/ieomd-deploy deploy --dir /opt/ieomd --backend-image ${backend} --web-image ${web}"
 
       - name: Smoke test
         run: |

--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -138,7 +138,7 @@ jobs:
           backend="ghcr.io/${GITHUB_REPOSITORY_OWNER}/in-the-event-of-my-death-backend:v${version}"
           web="ghcr.io/${GITHUB_REPOSITORY_OWNER}/in-the-event-of-my-death-web:v${version}"
           ssh -o BatchMode=yes -o ConnectTimeout=10 "${{ secrets.PROD_SSH_USER }}@${{ secrets.PROD_SSH_HOST }}" \
-            "INTERNAL_API_KEY='${{ secrets.INTERNAL_API_KEY }}' sudo -E /usr/local/bin/ieomd-deploy deploy --dir /opt/ieomd --backend-image ${backend} --web-image ${web}"
+            "sudo INTERNAL_API_KEY='${{ secrets.INTERNAL_API_KEY }}' /usr/local/bin/ieomd-deploy deploy --dir /opt/ieomd --backend-image ${backend} --web-image ${web}"
 
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Updates deploy-production.yml and promote-to-production.yml to pass `INTERNAL_API_KEY` from GitHub Secrets to the production server during deployment
- Uses `sudo VAR=value` syntax to set the env var for the deploy command (more reliable than `sudo -E` which can be blocked by sudoers config)

## Test plan
- [ ] Trigger a production deploy and verify the backend can validate tokens

Related to #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)