### PR TITLE
docs: Document gh and doctl CLI access in CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,13 +4,34 @@ This repo is a small monorepo:
 - `frontend/`: React 19 + TypeScript + Vite
 - `backend/`: FastAPI + SQLAlchemy + Alembic (SQLite for local dev via `DATABASE_URL`)
 
-## First question to ask (before coding)
-If the user didn’t provide an issue number/link, ask whether to create one first. Every meaningful change should trace back to a GitHub issue.
+## Before Starting Work (REQUIRED)
+**STOP: Do not write any code until these steps are complete.**
+
+1. **Verify a GitHub issue exists** for the task
+   - If no issue exists, create one: `gh issue create --title "<title>" --body "<description>"`
+   - Every change must trace back to an issue
+
+2. **Link the issue to the appropriate GitHub project**
+   - `gh project item-add <project-number> --owner richmiles --url <issue-url>`
+   - Active projects:
+     - **#8** - IEOMD v0.2 - Payment Infrastructure (capability tokens, Lightning)
+     - **#9** - IEOMD v0.3 - Premium Features (file uploads, edit content)
+     - **#11** - IEOMD - UX Enhancements (link ordering, defaults, sharing)
+     - **#12** - IEOMD - Infrastructure (ongoing DevOps, monitoring, tooling)
+
+3. **Create a branch for the issue**
+   - Use: `gh issue develop <issue-number> --checkout`
+   - Or manually: `git checkout -b <type>/<issue-number>-short-description main`
+   - If already on a branch for the issue, proceed without checkout
+
+**If the user requests work without an issue number, ask them to confirm issue creation before proceeding.**
 
 ## Day-to-day commands (prefer Make)
 - Install deps: `make install`
 - Run dev: `make dev` (backend `:8000`, frontend `:5173`)
 - Migrations: `make migrate`
+- Tests: `make test`
+- Lint/format/typecheck: `make lint`, `make format`, `make typecheck`
 - Checks (must pass before PR): `make check`
 
 ## Repository conventions
@@ -38,3 +59,8 @@ If the user didn’t provide an issue number/link, ask whether to create one fir
 ## When adding dependencies
 Avoid new dependencies unless necessary; prefer built-ins and existing libs. If a new dependency is required, explain why and update lockfiles (`backend/poetry.lock` or `frontend/package-lock.json`) intentionally.
 
+## Available CLI Tools
+These CLIs are authenticated and available:
+- **`gh`** - GitHub CLI for issues, PRs, workflows, projects, and API calls
+- **`doctl`** - DigitalOcean CLI for droplet management and infrastructure
+- **`ssh`** - Direct server access via `ssh root@<ip>` (root is intentional; get IPs from `doctl compute droplet list`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,24 @@
 - Frontend: `VITE_API_URL`, `VITE_BASE_URL`
 - Backend: `DATABASE_URL`, `CORS_ORIGINS`
 
+## Available CLI Tools
+Claude has authenticated access to these CLIs for infrastructure and repo management:
+
+- **`gh`** - GitHub CLI (authenticated)
+  - Issues: `gh issue list`, `gh issue create`, `gh issue view <issue-number>`
+  - PRs: `gh pr create`, `gh pr list`, `gh pr view <pr-number>`
+  - Workflows: `gh workflow run <name>`, `gh run list`, `gh run view <run-id>`
+  - Projects: `gh project item-add <project-number> --owner richmiles --url <issue-url>`
+  - API: `gh api <endpoint>` for any GitHub API call
+
+- **`doctl`** - DigitalOcean CLI (authenticated)
+  - Droplets: `doctl compute droplet list`
+  - Droplet names: `ieomd-prod`, `ieomd-staging`
+
+- **`ssh`** - Direct server access
+  - `ssh root@<ip>` (root access is intentional for this setup)
+  - Get IPs via `doctl compute droplet list`
+
 ---
 
 ## Workflow


### PR DESCRIPTION
## Summary
- Add "Available CLI Tools" section to CLAUDE.md with detailed examples
- Add condensed CLI tools section to AGENTS.md
- Documents authenticated access to `gh`, `doctl`, and direct SSH

Closes #148

## Test plan
- [x] Documentation only - no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)