### PR TITLE
fix: Send button appears disabled when it isn't

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -41,8 +41,8 @@
     --text-subtle: #737373;
 
     /* Accent */
-    --accent-primary: #737373;
-    --accent-hover: #a3a3a3;
+    --accent-primary: #a3a3a3;
+    --accent-hover: #b5b5b5;
 
     /* Borders & dividers */
     --border-subtle: #1f1f1f;


### PR DESCRIPTION
## Summary
- Fixed dark theme button contrast issue where enabled and disabled states used the same color (#737373)
- Enabled buttons now use a lighter color (#a3a3a3) with a subtle hover effect (#b5b5b5)
- Disabled buttons remain at #737373 (via --text-subtle), creating clear visual hierarchy

## Test plan
- [x] Verified in browser with dark mode enabled
- [x] Disabled state: darker gray (#737373)
- [x] Enabled state: lighter gray (#a3a3a3)  
- [x] Hover state: subtle lift effect (#b5b5b5)
- [x] Light theme unaffected
- [x] `make check` passes

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)