### PR TITLE
Fix: include deploy/Caddyfile in Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -50,4 +50,5 @@ frontend/.vite/
 
 # Deploy scripts (not needed in container)
 deploy/
+!deploy/Caddyfile
 scripts/


### PR DESCRIPTION
The web Dockerfile needs `deploy/Caddyfile` but it was excluded by `.dockerignore`.

This was causing the staging build to fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)