### PR TITLE
feat: Add pricing page with Free vs Premium tiers

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1196,6 +1196,106 @@ input[type='email']:focus {
   margin-bottom: 1.25rem;
 }
 
+/* Pricing page */
+.pricing {
+  text-align: center;
+}
+
+.pricing h1 {
+  font-size: 2rem;
+  margin: 0 0 0.5rem;
+  color: var(--text-primary);
+}
+
+.pricing .subtitle {
+  color: var(--text-secondary);
+  margin: 0 0 2rem;
+}
+
+.pricing-tiers {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.tier {
+  background: var(--bg-secondary);
+  padding: 2rem;
+  border-radius: 12px;
+  border: 1px solid var(--border-subtle);
+  text-align: center;
+}
+
+.tier h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.25rem;
+  color: var(--text-primary);
+}
+
+.tier-price {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.tier-price-note {
+  font-size: 0.875rem;
+  color: var(--text-subtle);
+  margin: 0 0 1rem;
+}
+
+.tier-features {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0;
+  text-align: left;
+}
+
+.tier-features li {
+  padding: 0.5rem 0;
+  color: var(--text-secondary);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.tier-features li:last-child {
+  border-bottom: none;
+}
+
+.tier-premium {
+  border-color: var(--accent-primary);
+  border-width: 2px;
+}
+
+/* Why Bitcoin page */
+.why-bitcoin {
+  text-align: center;
+}
+
+.why-bitcoin h1 {
+  font-size: 2rem;
+  margin: 0 0 0.5rem;
+  color: var(--text-primary);
+}
+
+.why-bitcoin .subtitle {
+  color: var(--text-secondary);
+  margin: 0 0 2rem;
+}
+
+.why-bitcoin code {
+  background: var(--bg-muted);
+  padding: 0.125rem 0.375rem;
+  border-radius: 4px;
+  font-size: 0.875rem;
+}
+
+.back-link {
+  margin-top: 2rem;
+  text-align: center;
+}
+
 /* About page */
 .about {
   text-align: center;
@@ -1280,6 +1380,14 @@ input[type='email']:focus {
     right: 0.5rem;
     font-size: 0.65rem;
     padding: 0.25rem 0.5rem;
+  }
+
+  .pricing-tiers {
+    grid-template-columns: 1fr;
+  }
+
+  .tier {
+    padding: 1.5rem;
   }
 
   .hero-form {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,8 @@ import ViewSecret from './pages/ViewSecret'
 import EditSecret from './pages/EditSecret'
 import About from './pages/About'
 import Feedback from './pages/Feedback'
+import Pricing from './pages/Pricing'
+import WhyBitcoin from './pages/WhyBitcoin'
 import PrivacyPolicy from './pages/PrivacyPolicy'
 import TermsOfService from './pages/TermsOfService'
 import './App.css'
@@ -22,6 +24,8 @@ function App() {
             <Route path="/edit" element={<EditSecret />} />
             <Route path="/about" element={<About />} />
             <Route path="/feedback" element={<Feedback />} />
+            <Route path="/pricing" element={<Pricing />} />
+            <Route path="/why-bitcoin" element={<WhyBitcoin />} />
             <Route path="/privacy" element={<PrivacyPolicy />} />
             <Route path="/terms" element={<TermsOfService />} />
           </Routes>
@@ -31,6 +35,8 @@ function App() {
           <div className="footer-content">
             <p className="footer-line">
               <Link to="/about">About</Link>
+              <span className="footer-separator">•</span>
+              <Link to="/pricing">Pricing</Link>
               <span className="footer-separator">•</span>
               <Link to="/feedback">Feedback</Link>
               <span className="footer-separator">•</span>

--- a/frontend/src/pages/Pricing.tsx
+++ b/frontend/src/pages/Pricing.tsx
@@ -1,0 +1,79 @@
+import { useEffect } from 'react'
+import { Link } from 'react-router-dom'
+
+export default function Pricing() {
+  useEffect(() => {
+    document.title = 'Pricing | In The Event Of My Death'
+  }, [])
+
+  return (
+    <div className="pricing">
+      <h1>Pricing</h1>
+      <p className="subtitle">Simple, one-time payments. No subscriptions.</p>
+
+      <div className="pricing-tiers">
+        <div className="tier tier-free">
+          <h2>Free</h2>
+          <p className="tier-price">$0</p>
+          <ul className="tier-features">
+            <li>Up to 10MB file attachments</li>
+            <li>365-day maximum expiry</li>
+            <li>End-to-end encryption</li>
+            <li>No account required</li>
+          </ul>
+          <Link to="/" className="button secondary">
+            Create a Secret
+          </Link>
+        </div>
+
+        <div className="tier tier-premium">
+          <h2>Premium</h2>
+          <p className="tier-price">$1</p>
+          <p className="tier-price-note">one-time payment</p>
+          <ul className="tier-features">
+            <li>Up to 500MB file attachments</li>
+            <li>5-year maximum expiry</li>
+            <li>End-to-end encryption</li>
+            <li>No account required</li>
+          </ul>
+          <button className="button primary" disabled>
+            Coming Soon
+          </button>
+        </div>
+      </div>
+
+      <section className="info-section">
+        <h2>What Premium Does Not Include</h2>
+        <p>
+          IEOMD is intentionally minimal. Premium unlocks larger limits, not features. To preserve
+          privacy, we do not offer:
+        </p>
+        <ul>
+          <li>
+            <strong>User accounts:</strong> No sign-up, no password, no profile.
+          </li>
+          <li>
+            <strong>Dashboards or analytics:</strong> We don&apos;t track your secrets or usage.
+          </li>
+          <li>
+            <strong>Usage history:</strong> Once created, secrets exist only via their links.
+          </li>
+          <li>
+            <strong>Content recovery:</strong> Lost link = lost secret. We cannot help recover it.
+          </li>
+        </ul>
+      </section>
+
+      <section className="info-section">
+        <h2>Why Bitcoin?</h2>
+        <p>
+          We accept Bitcoin payments through BTCPay Server, a self-hosted payment processor. This
+          aligns with IEOMD&apos;s privacy-first approach.
+        </p>
+        <p>
+          <Link to="/why-bitcoin">Learn more about our payment infrastructure</Link>
+        </p>
+      </section>
+    </div>
+  )
+}

--- a/frontend/src/pages/WhyBitcoin.tsx
+++ b/frontend/src/pages/WhyBitcoin.tsx
@@ -1,0 +1,79 @@
+import { useEffect } from 'react'
+import { Link } from 'react-router-dom'
+
+export default function WhyBitcoin() {
+  useEffect(() => {
+    document.title = 'Why Bitcoin | In The Event Of My Death'
+  }, [])
+
+  return (
+    <div className="why-bitcoin">
+      <h1>Why Bitcoin?</h1>
+      <p className="subtitle">How we handle payments without compromising privacy.</p>
+
+      <section className="info-section">
+        <h2>No Payment Processor Intermediary</h2>
+        <p>
+          Traditional payment processors (Stripe, PayPal, Square) require merchant accounts, KYC
+          verification, and access to transaction data. With BTCPay Server, payments go directly
+          from you to us with no third party in between.
+        </p>
+      </section>
+
+      <section className="info-section">
+        <h2>Privacy Alignment</h2>
+        <p>
+          IEOMD is built on zero-knowledge principles: we cannot read your secrets, and we
+          don&apos;t track who creates them. Using a self-hosted payment processor means payment
+          data stays consistent with this model.
+        </p>
+        <p>We collect the minimum data needed to process a payment:</p>
+        <ul>
+          <li>Payment amount and confirmation</li>
+          <li>A capability token tied to your secret (not your identity)</li>
+        </ul>
+        <p>We do not collect:</p>
+        <ul>
+          <li>Names, emails, or addresses</li>
+          <li>IP addresses or browser fingerprints</li>
+          <li>Purchase history or usage patterns</li>
+        </ul>
+      </section>
+
+      <section className="info-section">
+        <h2>Simple One-Time Payments</h2>
+        <p>
+          Premium is a one-time $1 payment, not a subscription. Bitcoin&apos;s transaction model is
+          well-suited for this: pay once, receive a capability token, done. No recurring billing, no
+          payment method on file, no renewal notices.
+        </p>
+      </section>
+
+      <section className="info-section">
+        <h2>Self-Hosted Infrastructure</h2>
+        <p>
+          Our payment processor runs on infrastructure we control at <code>pay.sparkswarm.com</code>
+          . BTCPay Server is open-source software that we deploy and maintain ourselves. This means:
+        </p>
+        <ul>
+          <li>No external service has access to transaction data</li>
+          <li>We control uptime and availability</li>
+          <li>No vendor lock-in or platform risk</li>
+        </ul>
+      </section>
+
+      <section className="info-section">
+        <h2>What About Other Cryptocurrencies?</h2>
+        <p>
+          BTCPay Server supports Bitcoin and Lightning Network. We may add additional payment
+          methods in the future based on user demand, but our priority is keeping the payment
+          experience simple and reliable.
+        </p>
+      </section>
+
+      <p className="back-link">
+        <Link to="/pricing">Back to Pricing</Link>
+      </p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds `/pricing` route with Free vs Premium ($1) tier comparison
- Adds `/why-bitcoin` route explaining BTCPay Server integration
- Adds Pricing link to footer navigation
- Responsive design for mobile (tiers stack vertically)

Closes #219

## Test plan
- [ ] Visit `/pricing` and verify Free/Premium tiers display correctly
- [ ] Click "Learn more about our payment infrastructure" link to `/why-bitcoin`
- [ ] Verify footer shows new "Pricing" link
- [ ] Resize browser to verify responsive layout (tiers stack on mobile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)