### PR TITLE
feat: Add Umami analytics with privacy disclosure

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -33,6 +33,13 @@
     <meta name="twitter:image" content="https://ieomd.com/og-image.png" />
 
     <title>In The Event Of My Death - Time-Locked Secrets</title>
+
+    <!-- Umami Analytics (privacy-focused, self-hosted) -->
+    <script
+      defer
+      src="https://analytics.sparkswarm.com/script.js"
+      data-website-id="27b6e303-35e4-46e1-9ec2-57baec9ccf53"
+    ></script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/pages/About.tsx
+++ b/frontend/src/pages/About.tsx
@@ -43,6 +43,16 @@ export default function About() {
         </ul>
       </section>
 
+      <section id="analytics" className="info-section">
+        <h2>Analytics</h2>
+        <p>
+          We use <a href="https://umami.is">Umami</a>, a privacy-focused analytics service we host
+          ourselves at analytics.sparkswarm.com. Umami does not use cookies, does not track
+          individuals across sites, and does not collect personal information. We only see aggregate
+          page views and browser statistics to understand how people use IEOMD.
+        </p>
+      </section>
+
       <section id="faq" className="info-section">
         <h2>FAQ</h2>
         <div className="faq-item">


### PR DESCRIPTION
## Summary
- Adds Umami tracking script to `index.html` (self-hosted at analytics.sparkswarm.com)
- Adds "Analytics" section to About page with clear privacy disclosure

Closes #220

## Privacy Disclosure
> We use Umami, a privacy-focused analytics service we host ourselves at analytics.sparkswarm.com. Umami does not use cookies, does not track individuals across sites, and does not collect personal information. We only see aggregate page views and browser statistics to understand how people use IEOMD.

## Test plan
- [ ] Visit site and verify Umami script loads (check Network tab for script.js)
- [ ] Verify no cookies are set (check Application > Cookies)
- [ ] Check Umami dashboard shows page view after visiting
- [ ] Visit `/about` and verify Analytics section appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)