### PR TITLE
feat: add BTCPay webhook handler for payment processing (#222)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -29,6 +29,10 @@ RATE_LIMIT_RETRIEVES=30/minute
 # Generate with: python -c "import secrets; print(secrets.token_hex(32))"
 # INTERNAL_API_KEY=your-secret-api-key-here
 
+# BTCPay Server Webhook
+# Set this to the webhook secret from BTCPay Store Settings > Webhooks
+# BTCPAY_WEBHOOK_SECRET=your-webhook-secret-here
+
 # Object Storage (S3-compatible; e.g. DigitalOcean Spaces, MinIO)
 # For local dev, start MinIO with: docker compose up -d minio minio-init
 OBJECT_STORAGE_ENABLED=false

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -50,6 +50,11 @@ class Settings(BaseSettings):
 
     # Capability Tokens
     capability_tiers: dict = {
+        "premium": {
+            "max_file_size_bytes": 50_000_000,  # 50MB
+            "max_expiry_days": 1825,  # 5 years
+            "price_usd": 1.00,
+        },
         "basic": {
             "max_file_size_bytes": 10_000_000,
             "max_expiry_days": 365,
@@ -69,6 +74,9 @@ class Settings(BaseSettings):
     rate_limit_token_create: str = "100/minute"
     rate_limit_token_validate: str = "60/minute"
     internal_api_key: str | None = None
+
+    # BTCPay Server
+    btcpay_webhook_secret: str | None = None
 
     # Object Storage (S3-compatible; e.g. DigitalOcean Spaces, MinIO)
     object_storage_enabled: bool = False

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,7 +15,14 @@ from app.database import engine
 from app.logging_config import get_logger, setup_logging
 from app.middleware.logging import LoggingMiddleware
 from app.middleware.rate_limit import limiter
-from app.routers import attachments, capability_tokens, challenges, feedback, secrets
+from app.routers import (
+    attachments,
+    btcpay_webhook,
+    capability_tokens,
+    challenges,
+    feedback,
+    secrets,
+)
 from app.scheduler import shutdown_scheduler, start_scheduler
 from app.services.matrix_service import send_error_alert
 
@@ -170,6 +177,7 @@ app.include_router(capability_tokens.router, prefix="/api/v1", tags=["capability
 app.include_router(challenges.router, prefix="/api/v1", tags=["challenges"])
 app.include_router(feedback.router, prefix="/api/v1", tags=["feedback"])
 app.include_router(secrets.router, prefix="/api/v1", tags=["secrets"])
+app.include_router(btcpay_webhook.router, prefix="/api/v1", tags=["btcpay"])
 
 
 @app.get("/health")

--- a/backend/app/routers/btcpay_webhook.py
+++ b/backend/app/routers/btcpay_webhook.py
@@ -1,0 +1,209 @@
+"""BTCPay Server webhook handler for payment notifications."""
+
+import hashlib
+import hmac
+
+import structlog
+from fastapi import APIRouter, Header, HTTPException, Request
+
+from app.config import settings
+from app.database import SessionLocal
+from app.services.capability_token_service import create_capability_token
+
+router = APIRouter()
+logger = structlog.get_logger()
+
+
+def verify_btcpay_signature(payload: bytes, signature: str, secret: str) -> bool:
+    """
+    Verify BTCPay webhook signature.
+
+    BTCPay uses HMAC-SHA256 with the webhook secret.
+    The signature header format is: sha256=<hex_digest>
+    """
+    if not signature.startswith("sha256="):
+        return False
+
+    expected_sig = signature[7:]  # Remove "sha256=" prefix
+    computed_sig = hmac.new(
+        secret.encode("utf-8"),
+        payload,
+        hashlib.sha256,
+    ).hexdigest()
+
+    return hmac.compare_digest(computed_sig, expected_sig)
+
+
+@router.post("/btcpay-webhook")
+async def handle_btcpay_webhook(
+    request: Request,
+    btcpay_sig: str = Header(None, alias="BTCPay-Sig"),
+):
+    """
+    Handle BTCPay webhook notifications.
+
+    Creates capability tokens when invoices are settled.
+    """
+    # Check if webhook is configured
+    if not settings.btcpay_webhook_secret:
+        logger.warning("btcpay_webhook_not_configured")
+        raise HTTPException(status_code=503, detail="Webhook not configured")
+
+    # Get raw body for signature verification
+    body = await request.body()
+
+    # Verify signature
+    if not btcpay_sig or not verify_btcpay_signature(
+        body, btcpay_sig, settings.btcpay_webhook_secret
+    ):
+        logger.warning("btcpay_webhook_invalid_signature")
+        raise HTTPException(status_code=401, detail="Invalid signature")
+
+    # Parse the webhook payload
+    try:
+        payload = await request.json()
+    except Exception:
+        logger.error("btcpay_webhook_invalid_json")
+        raise HTTPException(status_code=400, detail="Invalid JSON")
+
+    event_type = payload.get("type")
+    invoice_id = payload.get("invoiceId")
+
+    logger.info(
+        "btcpay_webhook_received",
+        event_type=event_type,
+        invoice_id=invoice_id,
+    )
+
+    # Only process settled invoices
+    if event_type != "InvoiceSettled":
+        # Acknowledge but don't process other events
+        return {"status": "ignored", "reason": f"Event type {event_type} not handled"}
+
+    # Check if we already processed this invoice (idempotency)
+    # The payment_reference field stores the invoice ID
+    db = SessionLocal()
+    try:
+        from app.models.capability_token import CapabilityToken
+
+        existing = (
+            db.query(CapabilityToken)
+            .filter(
+                CapabilityToken.payment_provider == "btcpay",
+                CapabilityToken.payment_reference == invoice_id,
+            )
+            .first()
+        )
+
+        if existing:
+            logger.info(
+                "btcpay_webhook_already_processed",
+                invoice_id=invoice_id,
+                token_id=existing.id,
+            )
+            return {"status": "already_processed", "invoice_id": invoice_id}
+
+        # Create capability token for the premium tier
+        token_model, raw_token = create_capability_token(
+            db=db,
+            tier="premium",
+            payment_provider="btcpay",
+            payment_reference=invoice_id,
+            token_metadata={
+                "amount": payload.get("amount"),
+                "currency": payload.get("currency"),
+            },
+        )
+
+        # Store raw token for one-time retrieval (cleared after user retrieves it)
+        token_model.token_metadata = {
+            **(token_model.token_metadata or {}),
+            "_pending_token": raw_token,
+        }
+        db.commit()
+
+        logger.info(
+            "btcpay_capability_token_created",
+            invoice_id=invoice_id,
+            token_id=token_model.id,
+            tier="premium",
+        )
+
+        return {
+            "status": "success",
+            "invoice_id": invoice_id,
+            "token_created": True,
+        }
+
+    except Exception as e:
+        logger.error(
+            "btcpay_webhook_error",
+            invoice_id=invoice_id,
+            error=str(e),
+        )
+        raise HTTPException(status_code=500, detail="Internal error")
+    finally:
+        db.close()
+
+
+@router.get("/payment-token")
+async def get_payment_token(invoice_id: str):
+    """
+    Retrieve capability token for a completed payment.
+
+    Called by the frontend after BTCPay redirect.
+    Returns the token once and clears it from pending storage.
+    """
+    if not invoice_id:
+        raise HTTPException(status_code=400, detail="invoice_id required")
+
+    db = SessionLocal()
+    try:
+        from app.models.capability_token import CapabilityToken
+
+        token = (
+            db.query(CapabilityToken)
+            .filter(
+                CapabilityToken.payment_provider == "btcpay",
+                CapabilityToken.payment_reference == invoice_id,
+            )
+            .first()
+        )
+
+        if not token:
+            return {
+                "status": "pending",
+                "message": "Payment not yet confirmed. Please wait.",
+            }
+
+        metadata = token.token_metadata or {}
+        raw_token = metadata.get("_pending_token")
+
+        if not raw_token:
+            # Token was already retrieved
+            return {
+                "status": "already_retrieved",
+                "message": "Token was already retrieved.",
+            }
+
+        # Clear the pending token (one-time retrieval)
+        metadata.pop("_pending_token", None)
+        token.token_metadata = metadata
+        db.commit()
+
+        logger.info(
+            "btcpay_token_retrieved",
+            invoice_id=invoice_id,
+            token_id=token.id,
+        )
+
+        return {
+            "status": "success",
+            "token": raw_token,
+            "tier": token.tier,
+            "max_file_size_bytes": token.max_file_size_bytes,
+            "max_expiry_days": token.max_expiry_days,
+        }
+
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary
- Wire up BTCPay Server webhooks to create capability tokens when payments are confirmed
- Add `/api/v1/btcpay-webhook` endpoint that receives InvoiceSettled events and verifies HMAC-SHA256 signature
- Add `/api/v1/payment-token` endpoint for one-time token retrieval after payment redirect
- Add "premium" tier ($1 for 50MB files, 5yr expiry)
- Idempotent processing prevents duplicate token creation for same invoice

## Test plan
- [ ] Verify webhook endpoint accepts valid BTCPay signature
- [ ] Verify capability token is created for InvoiceSettled events
- [ ] Verify token can be retrieved once via /payment-token
- [ ] Verify second retrieval returns "already_retrieved" status
- [ ] E2E test: complete BTCPay payment and retrieve token

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)