### PR TITLE
feat: improve premium UX with token-in-URL flow (#230)

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1398,6 +1398,61 @@ input[type='email']:focus {
   margin-top: 1.5rem;
 }
 
+/* Premium banner on home page */
+.premium-banner {
+  background: linear-gradient(135deg, var(--bg-muted) 0%, rgba(59, 130, 246, 0.1) 100%);
+  border: 1px solid rgba(59, 130, 246, 0.3);
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+  text-align: left;
+}
+
+.premium-banner-content {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.premium-badge {
+  background: linear-gradient(135deg, #3b82f6, #8b5cf6);
+  color: white;
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.premium-benefits {
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+}
+
+.premium-banner-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.premium-banner-actions .button.small {
+  padding: 0.375rem 0.75rem;
+  font-size: 0.75rem;
+}
+
+.premium-banner-actions .button.text {
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+}
+
+.premium-banner-actions .button.text:hover {
+  color: var(--text-primary);
+}
+
 /* Why Bitcoin page */
 .why-bitcoin {
   text-align: center;

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { useSearchParams, useNavigate } from 'react-router-dom'
 import {
   generateAesKey,
   exportKey,
@@ -10,7 +11,13 @@ import {
   base64ToBytes,
   computePayloadHash,
 } from '../services/crypto'
-import { requestChallenge, createSecret, uploadAttachment } from '../services/api'
+import {
+  requestChallenge,
+  createSecret,
+  uploadAttachment,
+  validateCapabilityToken,
+  type CapabilityTokenInfo,
+} from '../services/api'
 import { solveChallenge } from '../services/pow'
 import { encodeSecretPayload, type AttachmentRef } from '../services/secretPayload'
 import { generateShareableLinks } from '../utils/urlFragments'
@@ -32,6 +39,8 @@ const MAX_TOTAL_SIZE_BYTES = 100 * 1024 * 1024 // 100MB total
 const MAX_FILES = 10
 
 export default function Home() {
+  const [searchParams] = useSearchParams()
+  const navigate = useNavigate()
   const [step, setStep] = useState<Step>('input')
   const [message, setMessage] = useState('')
   const [files, setFiles] = useState<File[]>([])
@@ -59,12 +68,41 @@ export default function Home() {
   const expiryRef = useRef<HTMLDivElement>(null)
   const attachmentInputRef = useRef<HTMLInputElement>(null)
 
+  // Premium token state
+  const [premiumToken, setPremiumToken] = useState<string | null>(null)
+  const [premiumInfo, setPremiumInfo] = useState<CapabilityTokenInfo | null>(null)
+  const [tokenCopied, setTokenCopied] = useState(false)
+
   // Tick state to trigger re-renders for live time updates
   const [, setTick] = useState(0)
 
   useEffect(() => {
     document.title = 'In The Event Of My Death'
   }, [])
+
+  // Check for premium token in URL
+  useEffect(() => {
+    const token = searchParams.get('token')
+    if (token && token.length === 64) {
+      setPremiumToken(token)
+      // Validate the token
+      validateCapabilityToken(token)
+        .then((info) => {
+          setPremiumInfo(info)
+          if (!info.valid) {
+            setError(info.error || 'Invalid premium token')
+            setPremiumToken(null)
+            // Clear invalid token from URL
+            navigate('/', { replace: true })
+          }
+        })
+        .catch(() => {
+          setError('Failed to validate premium token')
+          setPremiumToken(null)
+          navigate('/', { replace: true })
+        })
+    }
+  }, [searchParams, navigate])
 
   useEffect(() => {
     // Only tick when on input step and using non-custom presets (they depend on current time)
@@ -239,25 +277,33 @@ export default function Home() {
         createRequest.expires_at = expiresAt.toISOString()
       }
 
-      if (ciphertextSize > MAX_POW_CIPHERTEXT_BYTES) {
-        throw new Error(
-          'This secret is too large. Please reduce the message size or file attachments.',
-        )
+      let response
+      if (premiumToken && premiumInfo?.valid) {
+        // Premium path: skip PoW, use capability token
+        setProgress('Creating premium secret...')
+        response = await createSecret(createRequest, { capabilityToken: premiumToken })
+      } else {
+        // Free path: require PoW
+        if (ciphertextSize > MAX_POW_CIPHERTEXT_BYTES) {
+          throw new Error(
+            'This secret is too large. Please reduce the message size or file attachments.',
+          )
+        }
+
+        // Request PoW challenge
+        setProgress('Requesting proof-of-work challenge...')
+        const challenge = await requestChallenge(payloadHash, ciphertextSize)
+
+        // Solve PoW
+        setProgress(`Solving proof-of-work (difficulty: ${challenge.difficulty})...`)
+        const powProof = await solveChallenge(challenge, payloadHash, (iterations) => {
+          setProgress(`Solving proof-of-work... (${(iterations / 1000).toFixed(0)}k iterations)`)
+        })
+
+        createRequest.pow_proof = powProof
+        setProgress('Storing encrypted secret...')
+        response = await createSecret(createRequest)
       }
-
-      // Request PoW challenge
-      setProgress('Requesting proof-of-work challenge...')
-      const challenge = await requestChallenge(payloadHash, ciphertextSize)
-
-      // Solve PoW
-      setProgress(`Solving proof-of-work (difficulty: ${challenge.difficulty})...`)
-      const powProof = await solveChallenge(challenge, payloadHash, (iterations) => {
-        setProgress(`Solving proof-of-work... (${(iterations / 1000).toFixed(0)}k iterations)`)
-      })
-
-      createRequest.pow_proof = powProof
-      setProgress('Storing encrypted secret...')
-      const response = await createSecret(createRequest)
 
       // Step 5: Generate shareable links
       const encryptionKey = bytesToHex(keyBytes)
@@ -279,6 +325,31 @@ export default function Home() {
     setCopied(type)
     setTimeout(() => setCopied(null), 2000)
   }
+
+  const saveTokenForLater = useCallback(async () => {
+    if (!premiumToken) return
+    try {
+      await navigator.clipboard.writeText(premiumToken)
+      setTokenCopied(true)
+      setTimeout(() => setTokenCopied(false), 2000)
+    } catch {
+      // Fallback for older browsers
+      const textarea = document.createElement('textarea')
+      textarea.value = premiumToken
+      document.body.appendChild(textarea)
+      textarea.select()
+      document.execCommand('copy')
+      document.body.removeChild(textarea)
+      setTokenCopied(true)
+      setTimeout(() => setTokenCopied(false), 2000)
+    }
+  }, [premiumToken])
+
+  const clearPremiumToken = useCallback(() => {
+    setPremiumToken(null)
+    setPremiumInfo(null)
+    navigate('/', { replace: true })
+  }, [navigate])
 
   const shareLink = async (url: string) => {
     if (!navigator.share) return
@@ -310,6 +381,10 @@ export default function Home() {
     setCreatedExpiresAt(null)
     setLinks(null)
     setError(null)
+    // Clear premium token after use
+    setPremiumToken(null)
+    setPremiumInfo(null)
+    navigate('/', { replace: true })
   }
 
   const openAttachmentPicker = () => {
@@ -501,6 +576,27 @@ export default function Home() {
     <div className="home">
       <div className="hero-form">
         <p className="hero-title">In The Event Of My Death</p>
+
+        {premiumToken && premiumInfo?.valid && (
+          <div className="premium-banner">
+            <div className="premium-banner-content">
+              <span className="premium-badge">Premium Active</span>
+              <span className="premium-benefits">
+                Up to {Math.round((premiumInfo.max_file_size_bytes || 50_000_000) / 1_000_000)}MB
+                files, {Math.round((premiumInfo.max_expiry_days || 1825) / 365)}-year expiry
+              </span>
+            </div>
+            <div className="premium-banner-actions">
+              <button type="button" onClick={saveTokenForLater} className="button secondary small">
+                {tokenCopied ? 'Copied!' : 'Save token for later'}
+              </button>
+              <button type="button" onClick={clearPremiumToken} className="button text small">
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+
         <form onSubmit={handleSubmit} className="inline-form">
           <div
             className={`message-input-container${dragActive ? ' drag-active' : ''}`}

--- a/frontend/src/pages/PaymentSuccess.tsx
+++ b/frontend/src/pages/PaymentSuccess.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from 'react'
-import { useSearchParams, Link } from 'react-router-dom'
+import { useSearchParams, Link, useNavigate } from 'react-router-dom'
 
 interface TokenResponse {
   status: 'pending' | 'success' | 'already_retrieved'
@@ -13,16 +13,12 @@ interface TokenResponse {
 export default function PaymentSuccess() {
   const [searchParams] = useSearchParams()
   const invoiceId = searchParams.get('invoiceId')
+  const navigate = useNavigate()
 
   const [status, setStatus] = useState<
     'loading' | 'pending' | 'success' | 'error' | 'already_retrieved'
   >('loading')
-  const [token, setToken] = useState<string | null>(null)
-  const [tierInfo, setTierInfo] = useState<{ maxFileSize: number; maxExpiryDays: number } | null>(
-    null,
-  )
   const [error, setError] = useState<string | null>(null)
-  const [copied, setCopied] = useState(false)
 
   useEffect(() => {
     document.title = 'Payment Complete | In The Event Of My Death'
@@ -42,12 +38,8 @@ export default function PaymentSuccess() {
       const data: TokenResponse = await response.json()
 
       if (data.status === 'success' && data.token) {
-        setToken(data.token)
-        setTierInfo({
-          maxFileSize: data.max_file_size_bytes || 50_000_000,
-          maxExpiryDays: data.max_expiry_days || 1825,
-        })
-        setStatus('success')
+        // Redirect to home with token - user can create secret immediately
+        navigate(`/?token=${encodeURIComponent(data.token)}`, { replace: true })
       } else if (data.status === 'pending') {
         setStatus('pending')
       } else if (data.status === 'already_retrieved') {
@@ -60,7 +52,7 @@ export default function PaymentSuccess() {
       setStatus('error')
       setError('Failed to retrieve token. Please try again.')
     }
-  }, [invoiceId])
+  }, [invoiceId, navigate])
 
   // Initial fetch and polling for pending status
   useEffect(() => {
@@ -75,29 +67,6 @@ export default function PaymentSuccess() {
 
     return () => clearInterval(interval)
   }, [fetchToken, status])
-
-  const copyToken = async () => {
-    if (!token) return
-    try {
-      await navigator.clipboard.writeText(token)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
-    } catch {
-      // Fallback for older browsers
-      const textarea = document.createElement('textarea')
-      textarea.value = token
-      document.body.appendChild(textarea)
-      textarea.select()
-      document.execCommand('copy')
-      document.body.removeChild(textarea)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
-    }
-  }
-
-  const formatFileSize = (bytes: number) => {
-    return `${Math.round(bytes / 1_000_000)}MB`
-  }
 
   if (!invoiceId) {
     return (
@@ -127,50 +96,6 @@ export default function PaymentSuccess() {
           <p>Your payment is being confirmed on the Bitcoin network.</p>
           <p>This page will update automatically. Please wait...</p>
           <div className="loading-spinner" aria-label="Waiting for confirmation" />
-        </>
-      )}
-
-      {status === 'success' && token && (
-        <>
-          <h1>Payment Complete!</h1>
-          <p>Thank you for your purchase. Here is your premium token:</p>
-
-          <div className="token-display">
-            <code className="token-value">{token}</code>
-            <button onClick={copyToken} className="button secondary copy-button">
-              {copied ? 'Copied!' : 'Copy Token'}
-            </button>
-          </div>
-
-          <div className="token-warning">
-            <strong>Important:</strong> Save this token now. It can only be displayed once and
-            cannot be recovered.
-          </div>
-
-          {tierInfo && (
-            <div className="tier-benefits">
-              <h3>Your Premium Benefits</h3>
-              <ul>
-                <li>Up to {formatFileSize(tierInfo.maxFileSize)} file attachments</li>
-                <li>{Math.round(tierInfo.maxExpiryDays / 365)}-year maximum expiry</li>
-              </ul>
-            </div>
-          )}
-
-          <div className="next-steps">
-            <h3>How to Use Your Token</h3>
-            <ol>
-              <li>
-                Go to the <Link to="/">home page</Link> to create a secret
-              </li>
-              <li>When prompted, enter your premium token</li>
-              <li>Your premium limits will be applied to that secret</li>
-            </ol>
-          </div>
-
-          <Link to="/" className="button primary">
-            Create a Premium Secret
-          </Link>
         </>
       )}
 

--- a/frontend/src/pages/PrivacyPolicy.tsx
+++ b/frontend/src/pages/PrivacyPolicy.tsx
@@ -66,12 +66,47 @@ export default function PrivacyPolicy() {
       </section>
 
       <section className="info-section">
-        <h2>Cookies and Analytics</h2>
+        <h2>Analytics</h2>
         <p>
-          We use minimal or no cookies for this service. Any analytics we collect are aggregated and
-          anonymized to help us improve the service. We do not track individual users or sell any
-          data to third parties.
+          We use{' '}
+          <a href="https://umami.is" target="_blank" rel="noopener noreferrer">
+            Umami
+          </a>
+          , a privacy-focused, open-source analytics platform. Umami does not use cookies, does not
+          track users across websites, and does not collect personal information. All data is
+          aggregated and anonymized. We use analytics solely to understand how the service is used
+          and to improve it.
         </p>
+        <p>
+          We do not sell any data to third parties. Analytics data is hosted on our own
+          infrastructure at analytics.sparkswarm.com.
+        </p>
+      </section>
+
+      <section className="info-section">
+        <h2>Payments</h2>
+        <p>
+          Premium features are paid for using Bitcoin via{' '}
+          <a href="https://btcpayserver.org" target="_blank" rel="noopener noreferrer">
+            BTCPay Server
+          </a>
+          , a self-hosted, open-source payment processor. We do not collect credit card information
+          or require personal details to purchase premium features.
+        </p>
+        <ul>
+          <li>
+            <strong>Payment processor:</strong> BTCPay Server, self-hosted at pay.sparkswarm.com
+          </li>
+          <li>
+            <strong>What we store:</strong> Invoice IDs and capability tokens linking payments to
+            premium features. We do not store Bitcoin addresses or transaction details beyond what
+            is needed to verify payment completion.
+          </li>
+          <li>
+            <strong>Capability tokens:</strong> After payment, you receive a one-time-use token that
+            grants premium features. This token is not linked to any personal information.
+          </li>
+        </ul>
       </section>
 
       <section className="info-section">

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -181,6 +181,25 @@ export async function submitFeedback(
 }
 
 /**
+ * Validate a capability token without consuming it.
+ * Returns tier information if valid.
+ */
+export interface CapabilityTokenInfo {
+  valid: boolean
+  tier?: string
+  max_file_size_bytes?: number
+  max_expiry_days?: number
+  error?: string
+}
+
+export async function validateCapabilityToken(token: string): Promise<CapabilityTokenInfo> {
+  const response = await fetch(`${API_BASE}/capability-tokens/validate`, {
+    headers: { 'X-Capability-Token': token },
+  })
+  return handleResponse<CapabilityTokenInfo>(response)
+}
+
+/**
  * Upload an encrypted file attachment to object storage.
  *
  * The attachment is created without being linked to a secret.


### PR DESCRIPTION
## Summary

- Improved premium user experience by redirecting to home page with token in URL after payment
- Home page detects and validates token, shows premium banner with benefits
- Users can create premium secrets immediately or save token for later use
- Updated privacy policy with Umami analytics and BTCPay payment disclosures

## Changes

**PaymentSuccess.tsx:**
- Now redirects to `/?token=xxx` instead of displaying token
- Removed unused token display UI

**Home.tsx:**
- Reads `token` from URL search params
- Validates token via `/api/v1/capability-tokens/validate`
- Shows premium banner when valid token present
- Passes capability token to createSecret (skips PoW)
- "Save token for later" copies token to clipboard
- "Cancel" clears token and redirects to clean URL

**PrivacyPolicy.tsx:**
- Added Analytics section mentioning Umami specifically
- Added Payments section explaining BTCPay integration

**api.ts:**
- Added `validateCapabilityToken()` function

## Test plan

- [ ] Pay via BTCPay, verify redirect to home with token
- [ ] Verify premium banner shows correct tier info
- [ ] Create a secret with premium token (verify no PoW prompt)
- [ ] "Save token for later" copies token to clipboard
- [ ] "Cancel" clears token from URL
- [ ] Invalid token shows error and clears URL


🤖 Generated with [Claude Code](https://claude.com/claude-code)