### PR TITLE
refactor: platform patterns audit — SQLAlchemy 2.0 select()

### DIFF
--- a/backend/app/routers/btcpay_webhook.py
+++ b/backend/app/routers/btcpay_webhook.py
@@ -84,16 +84,15 @@ async def handle_btcpay_webhook(
     # The payment_reference field stores the invoice ID
     db = SessionLocal()
     try:
+        from sqlalchemy import select
+
         from app.models.capability_token import CapabilityToken
 
-        existing = (
-            db.query(CapabilityToken)
-            .filter(
-                CapabilityToken.payment_provider == "btcpay",
-                CapabilityToken.payment_reference == invoice_id,
-            )
-            .first()
+        stmt = select(CapabilityToken).where(
+            CapabilityToken.payment_provider == "btcpay",
+            CapabilityToken.payment_reference == invoice_id,
         )
+        existing = db.scalars(stmt).first()
 
         if existing:
             logger.info(
@@ -159,16 +158,15 @@ async def get_payment_token(invoice_id: str):
 
     db = SessionLocal()
     try:
+        from sqlalchemy import select
+
         from app.models.capability_token import CapabilityToken
 
-        token = (
-            db.query(CapabilityToken)
-            .filter(
-                CapabilityToken.payment_provider == "btcpay",
-                CapabilityToken.payment_reference == invoice_id,
-            )
-            .first()
+        stmt = select(CapabilityToken).where(
+            CapabilityToken.payment_provider == "btcpay",
+            CapabilityToken.payment_reference == invoice_id,
         )
+        token = db.scalars(stmt).first()
 
         if not token:
             return {

--- a/backend/app/routers/secrets.py
+++ b/backend/app/routers/secrets.py
@@ -179,11 +179,16 @@ async def create_new_secret(
             # All-or-nothing: if not all attachments could be linked, fail the request
             # This can happen if attachments were deleted, already linked, or don't exist
             # Clean up: unlink any attachments that were linked and delete the secret
+            from sqlalchemy import update as sa_update
+
             from app.models.secret_attachment import SecretAttachment
 
-            db.query(SecretAttachment).filter(SecretAttachment.secret_id == secret.id).update(
-                {"secret_id": None}, synchronize_session=False
+            stmt = (
+                sa_update(SecretAttachment)
+                .where(SecretAttachment.secret_id == secret.id)
+                .values(secret_id=None)
             )
+            db.execute(stmt)
             db.delete(secret)
             db.commit()
             raise HTTPException(

--- a/backend/app/services/attachment_service.py
+++ b/backend/app/services/attachment_service.py
@@ -2,6 +2,7 @@ import base64
 import uuid
 from datetime import UTC, datetime, timedelta
 
+from sqlalchemy import select, update
 from sqlalchemy.orm import Session
 
 from app.config import settings
@@ -102,17 +103,18 @@ def link_attachments_to_secret(
         return 0
 
     # Update all matching attachments that are still orphaned
-    count = (
-        db.query(SecretAttachment)
-        .filter(
+    stmt = (
+        update(SecretAttachment)
+        .where(
             SecretAttachment.id.in_(attachment_ids),
             SecretAttachment.secret_id == None,  # noqa: E711 - Only link orphaned
         )
-        .update({"secret_id": secret_id}, synchronize_session=False)
+        .values(secret_id=secret_id)
     )
+    result = db.execute(stmt)
 
     db.commit()
-    return count
+    return result.rowcount
 
 
 def find_attachment_by_storage_key(
@@ -129,7 +131,8 @@ def find_attachment_by_storage_key(
     Returns:
         The attachment if found, None otherwise
     """
-    return db.query(SecretAttachment).filter(SecretAttachment.storage_key == storage_key).first()
+    stmt = select(SecretAttachment).where(SecretAttachment.storage_key == storage_key)
+    return db.scalars(stmt).first()
 
 
 def get_attachment_with_secret(
@@ -153,7 +156,8 @@ def get_attachment_with_secret(
     if attachment.secret_id is None:
         return None  # Orphaned attachment
 
-    secret = db.query(Secret).filter(Secret.id == attachment.secret_id).first()
+    stmt = select(Secret).where(Secret.id == attachment.secret_id)
+    secret = db.scalars(stmt).first()
     if secret is None:
         return None
 
@@ -178,14 +182,11 @@ def get_orphaned_attachments(
     """
     cutoff = datetime.now(UTC).replace(tzinfo=None) - timedelta(hours=max_age_hours)
 
-    return (
-        db.query(SecretAttachment)
-        .filter(
-            SecretAttachment.secret_id == None,  # noqa: E711 - Orphaned
-            SecretAttachment.created_at < cutoff,
-        )
-        .all()
+    stmt = select(SecretAttachment).where(
+        SecretAttachment.secret_id == None,  # noqa: E711 - Orphaned
+        SecretAttachment.created_at < cutoff,
     )
+    return db.scalars(stmt).all()
 
 
 async def delete_orphaned_attachments(

--- a/backend/app/services/capability_token_service.py
+++ b/backend/app/services/capability_token_service.py
@@ -2,6 +2,7 @@ import secrets
 import uuid
 from datetime import UTC, datetime, timedelta
 
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.config import settings
@@ -71,14 +72,11 @@ def find_capability_token(db: Session, raw_token: str) -> CapabilityToken | None
     Returns None if not found or already consumed.
     """
     prefix = get_token_prefix(raw_token)
-    candidates = (
-        db.query(CapabilityToken)
-        .filter(
-            CapabilityToken.token_prefix == prefix,
-            CapabilityToken.consumed_at == None,  # noqa: E711 - SQLAlchemy requires ==
-        )
-        .all()
+    stmt = select(CapabilityToken).where(
+        CapabilityToken.token_prefix == prefix,
+        CapabilityToken.consumed_at == None,  # noqa: E711 - SQLAlchemy requires ==
     )
+    candidates = db.scalars(stmt).all()
 
     for token in candidates:
         if verify_token(raw_token, token.token_hash):
@@ -98,14 +96,11 @@ def validate_capability_token(db: Session, raw_token: str) -> dict:
     if token is None:
         # Check if it was already consumed
         prefix = get_token_prefix(raw_token)
-        consumed_candidates = (
-            db.query(CapabilityToken)
-            .filter(
-                CapabilityToken.token_prefix == prefix,
-                CapabilityToken.consumed_at != None,  # noqa: E711
-            )
-            .all()
+        stmt = select(CapabilityToken).where(
+            CapabilityToken.token_prefix == prefix,
+            CapabilityToken.consumed_at != None,  # noqa: E711
         )
+        consumed_candidates = db.scalars(stmt).all()
         for consumed in consumed_candidates:
             if verify_token(raw_token, consumed.token_hash):
                 return {"valid": False, "consumed": True, "error": "Token already consumed"}

--- a/backend/app/services/pow_service.py
+++ b/backend/app/services/pow_service.py
@@ -4,6 +4,8 @@ import secrets
 import uuid
 from datetime import UTC, datetime, timedelta
 
+from sqlalchemy import delete as sa_delete
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.config import settings
@@ -66,7 +68,8 @@ def validate_pow(
     Returns the Challenge if valid, raises ValueError with specific message if invalid.
     Use mark_challenge_used() after all other validations pass.
     """
-    challenge = db.query(Challenge).filter(Challenge.id == challenge_id).first()
+    stmt = select(Challenge).where(Challenge.id == challenge_id)
+    challenge = db.scalars(stmt).first()
 
     if not challenge:
         raise ValueError("Challenge not found")
@@ -109,10 +112,7 @@ def mark_challenge_used(db: Session, challenge: Challenge) -> None:
 
 def cleanup_expired_challenges(db: Session) -> int:
     """Delete expired challenges. Returns count of deleted rows."""
-    result = (
-        db.query(Challenge)
-        .filter(Challenge.expires_at < datetime.now(UTC).replace(tzinfo=None))
-        .delete()
-    )
+    stmt = sa_delete(Challenge).where(Challenge.expires_at < datetime.now(UTC).replace(tzinfo=None))
+    result = db.execute(stmt)
     db.commit()
-    return result
+    return result.rowcount

--- a/backend/app/services/secret_service.py
+++ b/backend/app/services/secret_service.py
@@ -3,6 +3,7 @@ import uuid
 from datetime import UTC, datetime
 
 from fastapi import HTTPException, status
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.models.secret import Secret
@@ -64,14 +65,11 @@ def find_secret_by_edit_token(db: Session, edit_token: str) -> Secret | None:
     but handled correctly by verifying the full hash.
     """
     prefix = get_token_prefix(edit_token)
-    candidates = (
-        db.query(Secret)
-        .filter(
-            Secret.edit_token_prefix == prefix,
-            Secret.is_deleted == False,  # noqa: E712
-        )
-        .all()
+    stmt = select(Secret).where(
+        Secret.edit_token_prefix == prefix,
+        Secret.is_deleted == False,  # noqa: E712
     )
+    candidates = db.scalars(stmt).all()
 
     for secret in candidates:
         if verify_token(edit_token, secret.edit_token_hash):
@@ -88,14 +86,11 @@ def find_secret_by_decrypt_token(db: Session, decrypt_token: str) -> Secret | No
     but handled correctly by verifying the full hash.
     """
     prefix = get_token_prefix(decrypt_token)
-    candidates = (
-        db.query(Secret)
-        .filter(
-            Secret.decrypt_token_prefix == prefix,
-            Secret.is_deleted == False,  # noqa: E712
-        )
-        .all()
+    stmt = select(Secret).where(
+        Secret.decrypt_token_prefix == prefix,
+        Secret.is_deleted == False,  # noqa: E712
     )
+    candidates = db.scalars(stmt).all()
 
     for secret in candidates:
         if verify_token(decrypt_token, secret.decrypt_token_hash):
@@ -110,7 +105,8 @@ def find_secret_by_id(db: Session, secret_id: uuid.UUID) -> Secret | None:
     The secret row is kept even after retrieval/expiry (ciphertext is cleared),
     so ID-based status checks must not filter on `is_deleted`.
     """
-    return db.query(Secret).filter(Secret.id == secret_id).first()
+    stmt = select(Secret).where(Secret.id == secret_id)
+    return db.scalars(stmt).first()
 
 
 # --- get_*_or_404 helpers (PLATFORM_PATTERNS.md) ---
@@ -290,18 +286,18 @@ def get_secrets_needing_cleanup(db: Session) -> list[tuple[uuid.UUID, list[str]]
 
     now = datetime.now(UTC).replace(tzinfo=None)
 
-    secrets = (
-        db.query(Secret)
+    stmt = (
+        select(Secret)
         .options(joinedload(Secret.attachments))
-        .filter(
+        .where(
             Secret.cleared_at == None,  # noqa: E711 - Not already cleared
             or_(
                 Secret.expires_at <= now,  # Expired
                 Secret.retrieved_at != None,  # noqa: E711 - Retrieved
             ),
         )
-        .all()
     )
+    secrets = db.scalars(stmt).unique().all()
 
     return [(secret.id, [att.storage_key for att in secret.attachments]) for secret in secrets]
 
@@ -316,16 +312,19 @@ def clear_secret_and_attachments(db: Session, secret_id: uuid.UUID) -> bool:
 
     Returns True if the secret was cleared, False if not found or already cleared.
     """
+    from sqlalchemy import delete as sa_delete
+
     from app.models.secret_attachment import SecretAttachment
 
     now = datetime.now(UTC).replace(tzinfo=None)
 
-    secret = db.query(Secret).filter(Secret.id == secret_id).first()
+    stmt = select(Secret).where(Secret.id == secret_id)
+    secret = db.scalars(stmt).first()
     if secret is None or secret.cleared_at is not None:
         return False
 
     # Explicitly delete attachment rows (CASCADE won't trigger on UPDATE)
-    db.query(SecretAttachment).filter(SecretAttachment.secret_id == secret_id).delete()
+    db.execute(sa_delete(SecretAttachment).where(SecretAttachment.secret_id == secret_id))
 
     # Clear the secret's ciphertext
     secret.ciphertext = None
@@ -356,27 +355,26 @@ def clear_expired_secrets(db: Session) -> tuple[int, list[str]]:
 
     Returns a tuple of (count of cleared secrets, empty list for compatibility).
     """
-    from sqlalchemy import or_
+    from sqlalchemy import or_, update
 
     now = datetime.now(UTC).replace(tzinfo=None)
 
-    result = (
-        db.query(Secret)
-        .filter(
+    stmt = (
+        update(Secret)
+        .where(
             Secret.cleared_at == None,  # noqa: E711 - Not already cleared
             or_(
                 Secret.expires_at <= now,  # Expired
                 Secret.retrieved_at != None,  # noqa: E711 - Retrieved
             ),
         )
-        .update(
-            {
-                "ciphertext": None,
-                "iv": None,
-                "auth_tag": None,
-                "cleared_at": now,
-            }
+        .values(
+            ciphertext=None,
+            iv=None,
+            auth_tag=None,
+            cleared_at=now,
         )
     )
+    result = db.execute(stmt)
     db.commit()
-    return result, []
+    return result.rowcount, []

--- a/backend/app/services/vault_service.py
+++ b/backend/app/services/vault_service.py
@@ -5,6 +5,7 @@ import uuid
 from datetime import UTC, datetime
 
 from fastapi import HTTPException, status
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.exceptions import ETagMismatchError, VaultBlobTooLargeError, VaultExistsError
@@ -31,7 +32,8 @@ def verify_sync_token(vault: Vault, sync_token: str) -> bool:
 
 
 def get_vault(db: Session, vault_id: str) -> Vault | None:
-    return db.query(Vault).filter(Vault.vault_id == vault_id).first()
+    stmt = select(Vault).where(Vault.vault_id == vault_id)
+    return db.scalars(stmt).first()
 
 
 def get_vault_or_404(db: Session, vault_id: str, sync_token: str) -> Vault:

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -7,6 +7,7 @@ import uuid
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock
 
+from sqlalchemy import select
 from starlette.requests import Request
 
 from app.middleware.rate_limit import get_real_client_ip
@@ -1146,11 +1147,8 @@ class TestRetrieveEndpoint:
         assert create_response.status_code == 201
 
         # Get the secret from the database
-        secret = (
-            db_session.query(Secret)
-            .filter(Secret.decrypt_token_prefix == test_data["decrypt_token"][:16])
-            .first()
-        )
+        stmt = select(Secret).where(Secret.decrypt_token_prefix == test_data["decrypt_token"][:16])
+        secret = db_session.scalars(stmt).first()
         assert secret is not None
 
         return secret, test_data

--- a/backend/tests/test_attachments.py
+++ b/backend/tests/test_attachments.py
@@ -7,6 +7,7 @@ from datetime import timedelta
 from unittest.mock import AsyncMock
 
 import pytest
+from sqlalchemy import select
 
 from app.main import app
 from app.models.secret_attachment import SecretAttachment
@@ -202,7 +203,8 @@ class TestAttachmentRetrieval:
             db_session.expire_all()
             from app.models.secret import Secret
 
-            refreshed_secret = db_session.query(Secret).filter(Secret.id == secret.id).first()
+            stmt = select(Secret).where(Secret.id == secret.id)
+            refreshed_secret = db_session.scalars(stmt).first()
             assert refreshed_secret is not None
             assert refreshed_secret.retrieved_at is None
             assert refreshed_secret.ciphertext is not None

--- a/backend/tests/test_pow_service.py
+++ b/backend/tests/test_pow_service.py
@@ -3,10 +3,17 @@
 from datetime import timedelta
 
 import pytest
+from sqlalchemy import select
 
 from app.models.challenge import Challenge
 from app.services.pow_service import cleanup_expired_challenges, generate_challenge
 from tests.test_utils import utcnow
+
+
+def _find_challenge(db_session, challenge_id):
+    """Helper: look up a Challenge by ID using select() style."""
+    stmt = select(Challenge).where(Challenge.id == challenge_id)
+    return db_session.scalars(stmt).first()
 
 
 @pytest.fixture
@@ -28,14 +35,14 @@ class TestCleanupExpiredChallenges:
         db_session.commit()
 
         # Verify it exists
-        assert db_session.query(Challenge).filter(Challenge.id == challenge.id).first() is not None
+        assert _find_challenge(db_session, challenge.id) is not None
 
         # Run cleanup
         deleted_count = cleanup_expired_challenges(db_session)
 
         # Verify it was deleted
         assert deleted_count == 1
-        assert db_session.query(Challenge).filter(Challenge.id == challenge.id).first() is None
+        assert _find_challenge(db_session, challenge.id) is None
 
     def test_cleanup_does_not_delete_valid_challenges(self, db_session, sample_payload_hash):
         """Test that non-expired challenges are not deleted."""
@@ -43,7 +50,7 @@ class TestCleanupExpiredChallenges:
         challenge = generate_challenge(db_session, sample_payload_hash, 100)
 
         # Verify it exists and is not expired
-        assert db_session.query(Challenge).filter(Challenge.id == challenge.id).first() is not None
+        assert _find_challenge(db_session, challenge.id) is not None
         assert challenge.expires_at > utcnow()
 
         # Run cleanup
@@ -51,7 +58,7 @@ class TestCleanupExpiredChallenges:
 
         # Verify it was not deleted
         assert deleted_count == 0
-        assert db_session.query(Challenge).filter(Challenge.id == challenge.id).first() is not None
+        assert _find_challenge(db_session, challenge.id) is not None
 
     def test_cleanup_mixed_challenges(self, db_session, sample_payload_hash):
         """Test cleanup with both expired and valid challenges."""
@@ -70,13 +77,8 @@ class TestCleanupExpiredChallenges:
 
         # Verify only expired was deleted
         assert deleted_count == 1
-        assert (
-            db_session.query(Challenge).filter(Challenge.id == valid_challenge_id).first()
-            is not None
-        )
-        assert (
-            db_session.query(Challenge).filter(Challenge.id == expired_challenge_id).first() is None
-        )
+        assert _find_challenge(db_session, valid_challenge_id) is not None
+        assert _find_challenge(db_session, expired_challenge_id) is None
 
     def test_cleanup_used_but_not_expired_challenges_remain(self, db_session, sample_payload_hash):
         """Test that used but not expired challenges are not deleted."""
@@ -90,4 +92,4 @@ class TestCleanupExpiredChallenges:
 
         # Verify it was not deleted (cleanup only targets expired, not used)
         assert deleted_count == 0
-        assert db_session.query(Challenge).filter(Challenge.id == challenge.id).first() is not None
+        assert _find_challenge(db_session, challenge.id) is not None

--- a/backend/tests/test_service.py
+++ b/backend/tests/test_service.py
@@ -5,6 +5,7 @@ import secrets
 from datetime import timedelta
 
 import pytest
+from sqlalchemy import func, select
 
 from app.services.secret_service import (
     TOKEN_PREFIX_LENGTH,
@@ -522,12 +523,10 @@ class TestAttachmentCleanup:
         db_session.commit()
 
         # Verify attachment exists
-        assert (
-            db_session.query(SecretAttachment)
-            .filter(SecretAttachment.secret_id == expired_secret.id)
-            .count()
-            == 1
+        count_stmt = select(func.count(SecretAttachment.id)).where(
+            SecretAttachment.secret_id == expired_secret.id
         )
+        assert db_session.execute(count_stmt).scalar() == 1
 
         # Clear the secret
         result = clear_secret_and_attachments(db_session, expired_secret.id)
@@ -540,12 +539,7 @@ class TestAttachmentCleanup:
         assert expired_secret.ciphertext is None
 
         # Verify attachment row is deleted
-        assert (
-            db_session.query(SecretAttachment)
-            .filter(SecretAttachment.secret_id == expired_secret.id)
-            .count()
-            == 0
-        )
+        assert db_session.execute(count_stmt).scalar() == 0
 
     def test_clear_secret_and_attachments_already_cleared(self, db_session, sample_tokens):
         """Test that already-cleared secrets return False."""


### PR DESCRIPTION
## Summary
- Convert all remaining legacy db.query() calls to SQLAlchemy 2.0 select() style
- 7 source files and 4 test files updated (20+ conversions)
- Per PLATFORM_PATTERNS.md §2 models & database

## Test plan
- [x] `make check` passes (lint, format, typecheck, 243 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)