### PR TITLE
chore: drop swarm.sparkswarm.com, use sparkswarm.com

### DIFF
--- a/.github/workflows/ephemeral-staging.yml
+++ b/.github/workflows/ephemeral-staging.yml
@@ -40,7 +40,7 @@ jobs:
       (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/stage') && github.actor == github.repository_owner)
     runs-on: ${{ fromJSON(github.event_name == 'workflow_dispatch' && inputs.runner_target == 'ubuntu-latest' && '"ubuntu-latest"' || '["self-hosted","linux","x64","do-1gb-canary"]') }}
     env:
-      SPARK_SWARM_API_URL: https://swarm.sparkswarm.com/api/v1
+      SPARK_SWARM_API_URL: https://sparkswarm.com/api/v1
     steps:
       - name: Resolve PR ref (issue_comment only)
         if: ${{ github.event_name == 'issue_comment' }}

--- a/.github/workflows/promote-production.yml
+++ b/.github/workflows/promote-production.yml
@@ -28,7 +28,7 @@ jobs:
   deploy:
     runs-on: ${{ fromJSON(inputs.runner_target == 'ubuntu-latest' && '"ubuntu-latest"' || '["self-hosted","linux","x64","do-1gb-canary"]') }}
     env:
-      SPARK_SWARM_API_URL: https://swarm.sparkswarm.com/api/v1
+      SPARK_SWARM_API_URL: https://sparkswarm.com/api/v1
       PROD_HOST: 159.65.241.127
     steps:
       - name: Checkout (target ref)


### PR DESCRIPTION
## Summary
- Update `SPARK_SWARM_API_URL` in CI workflow env to `https://sparkswarm.com/api/v1`. The legacy `swarm.sparkswarm.com` vhost was removed today; without this, the next ephemeral-stage / promote-production run would fail to reach the API.
- Coordinated cleanup; sibling PRs already merged across the fleet.

## Test plan
- [x] `make lint` passes
- [x] `make format-check` passes
- [ ] Next workflow run resolves `https://sparkswarm.com` and succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)