### PR TITLE
chore: ship runners-default-ubuntu commit + bump actions to Node 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
         description: "Runner target for manual runs"
         required: true
         type: choice
-        default: "self-hosted-canary"
+        default: "ubuntu-latest"
         options:
           - self-hosted-canary
           - ubuntu-latest
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   check:
-    runs-on: ${{ fromJSON(inputs.runner_target == 'ubuntu-latest' && '"ubuntu-latest"' || '["self-hosted","linux","x64","do-1gb-canary"]') }}
+    runs-on: ${{ fromJSON(inputs.runner_target == 'self-hosted-canary' && '["self-hosted","linux","x64","do-1gb-canary"]' || '"ubuntu-latest"') }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -52,7 +52,7 @@ jobs:
       - run: make check
 
   build_image:
-    runs-on: ${{ fromJSON(inputs.runner_target == 'ubuntu-latest' && '"ubuntu-latest"' || '["self-hosted","linux","x64","do-1gb-canary"]') }}
+    runs-on: ${{ fromJSON(inputs.runner_target == 'self-hosted-canary' && '["self-hosted","linux","x64","do-1gb-canary"]' || '"ubuntu-latest"') }}
     needs: check
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,19 +28,19 @@ jobs:
   check:
     runs-on: ${{ fromJSON(inputs.runner_target == 'self-hosted-canary' && '["self-hosted","linux","x64","do-1gb-canary"]' || '"ubuntu-latest"') }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
       - name: Install backend deps
         working-directory: backend
         run: uv sync --frozen
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"
@@ -55,7 +55,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runner_target == 'self-hosted-canary' && '["self-hosted","linux","x64","do-1gb-canary"]' || '"ubuntu-latest"') }}
     needs: check
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,22 +20,22 @@ jobs:
   check:
     runs-on: ${{ fromJSON(github.event_name == 'workflow_dispatch' && inputs.runner_target == 'self-hosted-canary' && '["self-hosted","linux","x64","do-1gb-canary"]' || '"ubuntu-latest"') }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
 
       - name: Install backend deps
         working-directory: backend
         run: uv sync --frozen
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"
@@ -51,8 +51,8 @@ jobs:
   docs_drift:
     runs-on: ${{ fromJSON(github.event_name == 'workflow_dispatch' && inputs.runner_target == 'self-hosted-canary' && '["self-hosted","linux","x64","do-1gb-canary"]' || '"ubuntu-latest"') }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Docs drift (fleet contract)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,14 @@ on:
         description: "Runner target for manual runs"
         required: true
         type: choice
-        default: "self-hosted-canary"
+        default: "ubuntu-latest"
         options:
           - self-hosted-canary
           - ubuntu-latest
 
 jobs:
   check:
-    runs-on: ${{ fromJSON(github.event_name == 'workflow_dispatch' && inputs.runner_target == 'ubuntu-latest' && '"ubuntu-latest"' || '["self-hosted","linux","x64","do-1gb-canary"]') }}
+    runs-on: ${{ fromJSON(github.event_name == 'workflow_dispatch' && inputs.runner_target == 'self-hosted-canary' && '["self-hosted","linux","x64","do-1gb-canary"]' || '"ubuntu-latest"') }}
     steps:
       - uses: actions/checkout@v4
 
@@ -49,7 +49,7 @@ jobs:
         run: make check
 
   docs_drift:
-    runs-on: ${{ fromJSON(github.event_name == 'workflow_dispatch' && inputs.runner_target == 'ubuntu-latest' && '"ubuntu-latest"' || '["self-hosted","linux","x64","do-1gb-canary"]') }}
+    runs-on: ${{ fromJSON(github.event_name == 'workflow_dispatch' && inputs.runner_target == 'self-hosted-canary' && '["self-hosted","linux","x64","do-1gb-canary"]' || '"ubuntu-latest"') }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/ephemeral-staging.yml
+++ b/.github/workflows/ephemeral-staging.yml
@@ -64,7 +64,7 @@ jobs:
           echo "ref=${{ github.event.inputs.ref }}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout (target ref)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.pr.outputs.ref || steps.manual.outputs.ref }}
 
@@ -102,7 +102,7 @@ jobs:
           token: ${{ secrets.DO_API_TOKEN }}
 
       - name: Checkout Spark Swarm runner
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: miles-automation/spark-swarm
           path: spark-swarm
@@ -110,7 +110,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/ephemeral-staging.yml
+++ b/.github/workflows/ephemeral-staging.yml
@@ -17,7 +17,7 @@ on:
         description: "Runner target for manual runs"
         required: true
         type: choice
-        default: "self-hosted-canary"
+        default: "ubuntu-latest"
         options:
           - self-hosted-canary
           - ubuntu-latest
@@ -38,7 +38,7 @@ jobs:
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/stage') && github.actor == github.repository_owner)
-    runs-on: ${{ fromJSON(github.event_name == 'workflow_dispatch' && inputs.runner_target == 'ubuntu-latest' && '"ubuntu-latest"' || '["self-hosted","linux","x64","do-1gb-canary"]') }}
+    runs-on: ${{ fromJSON(github.event_name == 'workflow_dispatch' && inputs.runner_target == 'self-hosted-canary' && '["self-hosted","linux","x64","do-1gb-canary"]' || '"ubuntu-latest"') }}
     env:
       SPARK_SWARM_API_URL: https://sparkswarm.com/api/v1
     steps:

--- a/.github/workflows/promote-production.yml
+++ b/.github/workflows/promote-production.yml
@@ -32,7 +32,7 @@ jobs:
       PROD_HOST: 159.65.241.127
     steps:
       - name: Checkout (target ref)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.ref }}
 
@@ -62,7 +62,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/ieomd-app:${{ steps.meta.outputs.tag }}
 
       - name: Checkout Spark Swarm runner
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: miles-automation/spark-swarm
           path: spark-swarm
@@ -70,7 +70,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/promote-production.yml
+++ b/.github/workflows/promote-production.yml
@@ -11,7 +11,7 @@ on:
         description: "Runner target for manual runs"
         required: true
         type: choice
-        default: "self-hosted-canary"
+        default: "ubuntu-latest"
         options:
           - self-hosted-canary
           - ubuntu-latest
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ${{ fromJSON(inputs.runner_target == 'ubuntu-latest' && '"ubuntu-latest"' || '["self-hosted","linux","x64","do-1gb-canary"]') }}
+    runs-on: ${{ fromJSON(inputs.runner_target == 'self-hosted-canary' && '["self-hosted","linux","x64","do-1gb-canary"]' || '"ubuntu-latest"') }}
     env:
       SPARK_SWARM_API_URL: https://sparkswarm.com/api/v1
       PROD_HOST: 159.65.241.127


### PR DESCRIPTION
## Summary

Two CI hygiene changes shipped together:

1. **`ci: default workflow runners to ubuntu-latest`** (commit `d3e80c6`, Apr 27 2026) — previously-unpushed local-main commit. Flips the workflow_dispatch default and the `runs-on` ternary so all events (push, PR, dispatch, schedule, issue_comment) land on `ubuntu-latest` by default, with `self-hosted-canary` remaining an explicit opt-in. The `do-1gb-canary` self-hosted runner OOM-died on 2026-03-19 and has been offline since, queueing jobs indefinitely against an unavailable runner.
2. **`chore: bump actions to Node-24-compatible versions`** — bumps the JS actions used in CI ahead of the forced 2026-06-16 Node 24 cutover. Node 20 is removed entirely on 2026-09-16, so we need to be on Node-24-capable action releases well before then.

## Concrete bumps

Across `.github/workflows/{build,ci,ephemeral-staging,promote-production}.yml`:

- `actions/checkout` `@v4` → `@v6`
- `actions/setup-python` `@v5` → `@v6`
- `actions/setup-node` `@v4` → `@v6`
- `astral-sh/setup-uv` `@v4` → `@v7`

No SHA-pinned actions were touched (none present for these four actions).

## Rationale

- **2026-06-16:** GitHub Actions forces Node 24 on JS actions. Older action releases that bundle Node 20 stop working.
- **2026-09-16:** Node 20 fully removed from the runner images.

## Fleet sweep context

Part of the fleet-wide Node 24 sweep — follow-up to code-loom #17, eshers-codex #25, human-index #151, platform-infra #43. This repo was skipped on the initial pass because local main had the unpushed `runners-default-ubuntu` commit; this PR ships that commit alongside the Node 24 bumps so nothing is lost.

## Test plan

- [ ] CI workflow runs green on this PR (`check` + `docs_drift` jobs on `ubuntu-latest`)
- [ ] Build workflow can still be dispatched against `ubuntu-latest`
- [ ] No regressions in `make check` (lint, format, typecheck) under the new action versions