### PR TITLE
fix(security): contain SPA catch-all to STATIC_DIR (LFI)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -243,9 +243,11 @@ if STATIC_DIR.exists():
         if full_path.startswith("api/") or full_path == "health":
             raise HTTPException(status_code=404, detail="Not found")
 
-        # Serve static file if it exists
-        file_path = STATIC_DIR / full_path
-        if file_path.is_file():
+        # Serve static file if it exists (must stay within STATIC_DIR;
+        # `STATIC_DIR / "/abs"` collapses to the absolute path, so guard it)
+        file_path = (STATIC_DIR / full_path).resolve()
+        static_root = STATIC_DIR.resolve()
+        if file_path.is_relative_to(static_root) and file_path.is_file():
             return FileResponse(file_path)
 
         # Otherwise serve index.html for client-side routing

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -229,6 +229,22 @@ async def api_healthz_check(db: Session = Depends(get_db)):
 
 
 # Static file serving for production (when frontend is built into ./static)
+def _safe_spa_file(static_root: Path, path: str) -> Path:
+    """Resolve a requested SPA path to a file inside ``static_root``.
+
+    ``static_root / path`` collapses to an absolute path when ``path`` is
+    absolute (e.g. ``//etc/passwd`` -> ``/etc/passwd``), and symlinks or
+    ``..`` segments can otherwise escape the static directory. Resolve the
+    candidate and require it to stay within the (resolved) static root
+    before serving it; anything else falls back to the SPA entrypoint.
+    """
+    candidate = (static_root / path).resolve()
+    root = static_root.resolve()
+    if candidate.is_relative_to(root) and candidate.is_file():
+        return candidate
+    return root / "index.html"
+
+
 STATIC_DIR = Path(__file__).parent.parent / "static"
 
 if STATIC_DIR.exists():
@@ -243,16 +259,9 @@ if STATIC_DIR.exists():
         if full_path.startswith("api/") or full_path == "health":
             raise HTTPException(status_code=404, detail="Not found")
 
-        # Serve static file if it exists (must stay within STATIC_DIR;
-        # `STATIC_DIR / "/abs"` collapses to the absolute path, so guard it)
-        file_path = (STATIC_DIR / full_path).resolve()
-        static_root = STATIC_DIR.resolve()
-        if file_path.is_relative_to(static_root) and file_path.is_file():
-            return FileResponse(file_path)
-
-        # Otherwise serve index.html for client-side routing
-        index_path = STATIC_DIR / "index.html"
-        if index_path.exists():
-            return FileResponse(index_path)
+        # Serve a contained static file, else the SPA entrypoint.
+        target = _safe_spa_file(STATIC_DIR, full_path)
+        if target.is_file():
+            return FileResponse(target)
 
         raise HTTPException(status_code=404, detail="Not found")

--- a/backend/tests/test_spa_security.py
+++ b/backend/tests/test_spa_security.py
@@ -1,0 +1,139 @@
+"""Regression tests for the SPA catch-all path-traversal (LFI) fix.
+
+The catch-all handler served ``STATIC_DIR / path`` without validating that the
+result stayed inside the static directory. Because ``Path.__truediv__``
+discards the left operand when the right side is absolute,
+``STATIC_DIR / "/etc/passwd"`` resolved to ``/etc/passwd`` and served it; ``..``
+segments and symlinks could escape the directory the same way.
+
+These tests pin the ``_safe_spa_file`` containment helper (unit level) and an
+HTTP route built on top of it (integration level). No real secret or system
+file is read: escape targets are temp files this test creates itself.
+"""
+
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.responses import FileResponse
+from fastapi.testclient import TestClient
+
+from app.main import _safe_spa_file
+
+
+def _make_static(tmp_path: Path) -> Path:
+    """Build a realistic static tree plus an out-of-root secret + symlink."""
+    static = tmp_path / "static"
+    (static / "assets").mkdir(parents=True)
+    (static / "index.html").write_text("<!doctype html>INDEX")
+    (static / "assets" / "app.js").write_text("APPJS")
+
+    secret = tmp_path / "secret.txt"
+    secret.write_text("TOP-SECRET")
+    link = static / "link.txt"
+    try:
+        link.symlink_to(secret)
+    except (OSError, NotImplementedError):  # pragma: no cover - platform guard
+        pass
+    return static
+
+
+# --- unit tests on the containment helper -------------------------------------
+
+
+def test_legit_nested_file_is_served(tmp_path):
+    static = _make_static(tmp_path)
+    assert _safe_spa_file(static, "assets/app.js") == (static / "assets" / "app.js").resolve()
+
+
+def test_index_is_served(tmp_path):
+    static = _make_static(tmp_path)
+    assert _safe_spa_file(static, "index.html") == (static / "index.html").resolve()
+
+
+def test_missing_path_falls_back_to_index(tmp_path):
+    static = _make_static(tmp_path)
+    assert _safe_spa_file(static, "some/client/route") == static.resolve() / "index.html"
+
+
+def test_absolute_system_path_is_rejected(tmp_path):
+    static = _make_static(tmp_path)
+    # Never returns /etc/passwd; falls back to index without reading it.
+    assert _safe_spa_file(static, "/etc/passwd") == static.resolve() / "index.html"
+
+
+def test_absolute_path_to_out_of_root_secret_is_rejected(tmp_path):
+    static = _make_static(tmp_path)
+    secret = tmp_path / "secret.txt"
+    assert _safe_spa_file(static, str(secret)) == static.resolve() / "index.html"
+
+
+def test_dotdot_traversal_is_rejected(tmp_path):
+    static = _make_static(tmp_path)
+    assert _safe_spa_file(static, "../secret.txt") == static.resolve() / "index.html"
+    assert _safe_spa_file(static, "../../etc/passwd") == static.resolve() / "index.html"
+
+
+def test_symlink_escaping_root_is_rejected(tmp_path):
+    static = _make_static(tmp_path)
+    if not (static / "link.txt").is_symlink():
+        import pytest
+
+        pytest.skip("symlinks unsupported on this platform")
+    assert _safe_spa_file(static, "link.txt") == static.resolve() / "index.html"
+
+
+# --- integration tests on the HTTP route --------------------------------------
+
+
+def _client(static: Path) -> TestClient:
+    app = FastAPI()
+
+    @app.get("/{path:path}")
+    async def spa_fallback(path: str):
+        return FileResponse(_safe_spa_file(static, path))
+
+    return TestClient(app)
+
+
+def test_http_legit_asset(tmp_path):
+    static = _make_static(tmp_path)
+    resp = _client(static).get("/assets/app.js")
+    assert resp.status_code == 200
+    assert resp.text == "APPJS"
+
+
+def test_http_spa_deeplink_returns_index(tmp_path):
+    static = _make_static(tmp_path)
+    resp = _client(static).get("/some/client/route")
+    assert resp.status_code == 200
+    assert "INDEX" in resp.text
+
+
+def test_http_root_returns_index(tmp_path):
+    static = _make_static(tmp_path)
+    resp = _client(static).get("/")
+    assert resp.status_code == 200
+    assert "INDEX" in resp.text
+
+
+def test_http_encoded_traversal_returns_index_not_secret(tmp_path):
+    static = _make_static(tmp_path)
+    client = _client(static)
+    # Percent-encoded so the client does not normalise it away; the ASGI
+    # server decodes to `../secret.txt` before the handler sees it.
+    for target in ("/%2e%2e/secret.txt", "/%2e%2e%2f%2e%2e%2fetc%2fpasswd"):
+        resp = client.get(target)
+        assert resp.status_code == 200
+        assert "TOP-SECRET" not in resp.text
+        assert "INDEX" in resp.text
+
+
+def test_http_symlink_returns_index_not_secret(tmp_path):
+    static = _make_static(tmp_path)
+    if not (static / "link.txt").is_symlink():
+        import pytest
+
+        pytest.skip("symlinks unsupported on this platform")
+    resp = _client(static).get("/link.txt")
+    assert resp.status_code == 200
+    assert "TOP-SECRET" not in resp.text


### PR DESCRIPTION
## Security fix: unauthenticated arbitrary file read (LFI)

**Severity:** critical, was live in production.

The SPA catch-all served `STATIC_DIR / full_path` with no containment check. pathlib drops the left operand when the right side is absolute, so `STATIC_DIR / "/etc/passwd"` → `/etc/passwd`. Any absolute path was served straight off the container filesystem, unauthenticated:

```
GET //etc/passwd        -> 200  root:x:0:0:root:/root:/bin/bash
GET //proc/self/environ -> 200  (leaks container env: DB creds, API keys)
```

Malformed streamed responses (`/proc/self/cmdline`, unreadable `/etc/shadow`) also threw `RuntimeError: Response content shorter/longer than Content-Length`, spamming the Matrix ops channel with 500 alerts.

### Fix
Resolve the candidate path and require `is_relative_to(STATIC_DIR)` before serving; otherwise fall through to `index.html`. Mirrors the existing `_safe_spa_file` guard already in spark-swarm (which is why that app was not vulnerable).

### Mitigation already applied
A Caddy-level `block_lfi` snippet (404s traversal / absolute-fs signatures) was reloaded on the platform droplet, closing the live exposure fleet-wide ahead of this deploy. Verified: exploit paths now 404, normal routes and SPA deep links still 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)